### PR TITLE
refactor: reuse ClickHouse SWR hook

### DIFF
--- a/src/hooks/useClickHouseSWR.ts
+++ b/src/hooks/useClickHouseSWR.ts
@@ -1,0 +1,24 @@
+import useSWR from "swr";
+import { z } from "zod";
+import { fetcher } from "../api/fetcher";
+import type { ClickHouseConfig } from "../api/fetcher";
+
+export function useClickHouseSWR<T extends { result: unknown }>(
+  url: string,
+  config: ClickHouseConfig,
+  schema: z.ZodSchema<T>
+) {
+  const key = `${url}:${config.baseUrl}:${config.keyId}`;
+  const { data, error, isLoading, isValidating, mutate } = useSWR(key, () =>
+    fetcher<T>(url, config, schema)
+  );
+  return {
+    data: data?.result,
+    error,
+    isLoading,
+    isValidating,
+    response: data,
+    mutate,
+  };
+}
+

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -1,6 +1,4 @@
-import useSWR, { useSWRConfig } from "swr";
-import { z } from "zod";
-import { fetcher } from "../api/fetcher";
+import { useSWRConfig } from "swr";
 import type { ClickHouseConfig } from "../api/fetcher";
 import {
   OrganizationsResponseSchema,
@@ -13,25 +11,7 @@ import {
   type PrivateEndpointConfigResponse,
   type Organization,
 } from "../schemas/schemas";
-
-function useClickHouseSWR<T extends { result: unknown }>(
-  url: string,
-  config: ClickHouseConfig,
-  schema: z.ZodSchema<T>
-) {
-  const key = `${url}:${config.baseUrl}:${config.keyId}`;
-  const { data, error, isLoading, isValidating, mutate } = useSWR(key, () =>
-    fetcher<T>(url, config, schema)
-  );
-  return {
-    data: data?.result,
-    error,
-    isLoading,
-    isValidating,
-    response: data,
-    mutate,
-  };
-}
+import { useClickHouseSWR } from "./useClickHouseSWR";
 
 export function useOrganizations(config: ClickHouseConfig) {
   return useClickHouseSWR<OrganizationsResponse>(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 export * from "./hooks/useApiKeys";
+export * from "./hooks/useClickHouseSWR";
 export * from "./hooks/useClickpipes";
 export * from "./hooks/useOrganizations";
 export * from "./hooks/useServices";

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -133,6 +133,24 @@ export const ActivitySchema = z.object({
   serviceId: z.string().optional(),
 });
 
+// API Key schemas
+export const IpAccessListEntrySchema = z.object({
+  source: z.string(),
+  description: z.string(),
+});
+
+export const ApiKeySchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  state: z.enum(["enabled", "disabled"]),
+  roles: z.array(z.enum(["admin", "developer", "query_endpoints"])),
+  keySuffix: z.string(),
+  createdAt: z.string().datetime(),
+  expireAt: z.string().datetime().nullable().optional(),
+  usedAt: z.string().datetime().nullable().optional(),
+  ipAccessList: z.array(IpAccessListEntrySchema).default([]),
+});
+
 // Usage Cost schemas
 export const UsageCostMetricsSchema = z.object({
   storageCHC: z.number().optional(),
@@ -169,6 +187,21 @@ export const OrganizationCloudRegionPrivateEndpointConfigSchema = z.object({
 });
 
 // Response schemas
+export const ApiKeysResponseSchema = ClickHouseBaseResponseSchema.extend({
+  result: z.array(ApiKeySchema),
+});
+
+export const ApiKeyResponseSchema = ClickHouseBaseResponseSchema.extend({
+  result: ApiKeySchema,
+});
+
+export const ApiKeyCreateResponseSchema = ClickHouseBaseResponseSchema.extend({
+  result: z.object({
+    key: ApiKeySchema,
+    keyId: z.string().optional(),
+    keySecret: z.string().optional(),
+  }),
+});
 export const OrganizationsResponseSchema = ClickHouseBaseResponseSchema.extend({
   result: z.array(OrganizationSchema),
 });
@@ -197,6 +230,7 @@ export const PrivateEndpointConfigResponseSchema =
 // Type exports
 export type Organization = z.infer<typeof OrganizationSchema>;
 export type Activity = z.infer<typeof ActivitySchema>;
+export type ApiKey = z.infer<typeof ApiKeySchema>;
 export type UsageCost = z.infer<typeof UsageCostSchema>;
 export type UsageCostRecord = z.infer<typeof UsageCostRecordSchema>;
 export type UsageCostMetrics = z.infer<typeof UsageCostMetricsSchema>;
@@ -209,6 +243,9 @@ export type OrganizationCloudRegionPrivateEndpointConfig = z.infer<
 >;
 
 // Response types
+export type ApiKeysResponse = z.infer<typeof ApiKeysResponseSchema>;
+export type ApiKeyResponse = z.infer<typeof ApiKeyResponseSchema>;
+export type ApiKeyCreateResponse = z.infer<typeof ApiKeyCreateResponseSchema>;
 export type OrganizationsResponse = z.infer<typeof OrganizationsResponseSchema>;
 export type OrganizationResponse = z.infer<typeof OrganizationResponseSchema>;
 export type ActivitiesResponse = z.infer<typeof ActivitiesResponseSchema>;


### PR DESCRIPTION
## Summary
- share `useClickHouseSWR` hook across hooks and export it
- switch API key hooks to use `useClickHouseSWR`
- add API key schemas

## Testing
- `yarn lint` (fails: Unexpected any. Specify a different type)
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6894e7bf346c8324a2513a104da959e7