### PR TITLE
Add tests and examples for organization hooks

### DIFF
--- a/example/src/App.css
+++ b/example/src/App.css
@@ -271,6 +271,34 @@
   font-weight: 500;
 }
 
+/* Navigation */
+.main-nav {
+  padding: 1rem;
+  border-bottom: 1px solid #eee;
+}
+
+.main-nav a:not(:last-child) {
+  margin-right: 1rem;
+}
+
+/* Common Spacing */
+.refresh-button {
+  margin-bottom: 1em;
+}
+
+.form-inline {
+  margin-bottom: 1em;
+}
+
+.input-inline {
+  margin-left: 0.5em;
+  margin-right: 1em;
+}
+
+.back-link {
+  margin-top: 1em;
+}
+
 /* Error Styles */
 .error {
   background-color: #f8d7da;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -5,6 +5,8 @@ import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
 import OrganizationListPage from "./pages/OrganizationListPage";
 import ConfigurationPage from "./pages/ConfigurationPage";
 import OrganizationDetailsPage from "./pages/OrganizationDetailsPage";
+import OrganizationUsageCostPage from "./pages/OrganizationUsageCostPage";
+import OrganizationPrivateEndpointConfigPage from "./pages/OrganizationPrivateEndpointConfigPage";
 
 function App() {
   return (
@@ -14,8 +16,8 @@ function App() {
           <h1>ClickHouse Cloud React Hooks Example</h1>
           <p>This example demonstrates ClickHouse Cloud API responses.</p>
         </header>
-        <nav style={{ padding: "1rem", borderBottom: "1px solid #eee" }}>
-          <Link to="/" style={{ marginRight: "1rem" }}>Organizations</Link>
+        <nav className="main-nav">
+          <Link to="/">Organizations</Link>
           <Link to="/config">Configuration</Link>
         </nav>
         <main>
@@ -23,6 +25,14 @@ function App() {
             <Route path="/" element={<OrganizationListPage />} />
             <Route path="/config" element={<ConfigurationPage />} />
             <Route path="/org/:id" element={<OrganizationDetailsPage />} />
+            <Route
+              path="/org/:id/usage-cost"
+              element={<OrganizationUsageCostPage />}
+            />
+            <Route
+              path="/org/:id/private-endpoint-config"
+              element={<OrganizationPrivateEndpointConfigPage />}
+            />
           </Routes>
         </main>
       </div>

--- a/example/src/pages/OrganizationDetailsPage.css
+++ b/example/src/pages/OrganizationDetailsPage.css
@@ -1,0 +1,20 @@
+.mr-sm {
+  margin-right: 0.5em;
+}
+
+.error-spacing {
+  margin-top: 0.5em;
+}
+
+.success-message {
+  color: green;
+  margin-top: 0.5em;
+}
+
+.link-container {
+  margin-top: 1em;
+}
+
+.link-container a:not(:last-child) {
+  margin-right: 1em;
+}

--- a/example/src/pages/OrganizationDetailsPage.tsx
+++ b/example/src/pages/OrganizationDetailsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import "../App.css";
+import "./OrganizationDetailsPage.css";
 import { useParams, Link } from "react-router-dom";
 import {
   useOrganization,
@@ -85,7 +86,6 @@ const OrganizationDetailsPage: React.FC = () => {
           setUpdateSuccess(false);
         }}
         className="refresh-button"
-        style={{ marginBottom: "1em" }}
         disabled={isValidating}
       >
         {isValidating ? "Loading..." : "Refresh"}
@@ -113,7 +113,7 @@ const OrganizationDetailsPage: React.FC = () => {
             setUpdateLoading(false);
           }
         }}
-        style={{ marginBottom: "1em" }}
+        className="form-inline"
       >
         <label>
           <strong>Name:</strong>{" "}
@@ -123,10 +123,10 @@ const OrganizationDetailsPage: React.FC = () => {
               value={editName}
               onChange={(e) => setEditName(e.target.value)}
               disabled={updateLoading}
-              style={{ marginRight: "0.5em" }}
+              className="mr-sm"
             />
           ) : (
-            <span style={{ marginRight: "0.5em" }}>{organization.name}</span>
+            <span className="mr-sm">{organization.name}</span>
           )}
         </label>
         {isEditing ? (
@@ -134,7 +134,7 @@ const OrganizationDetailsPage: React.FC = () => {
             <button
               type="submit"
               disabled={updateLoading || editName.trim() === ""}
-              style={{ marginRight: "0.5em" }}
+              className="mr-sm"
             >
               {updateLoading ? "Saving..." : "Save"}
             </button>
@@ -161,14 +161,10 @@ const OrganizationDetailsPage: React.FC = () => {
           </button>
         )}
         {updateError && (
-          <div className="error" style={{ marginTop: "0.5em" }}>
-            Error: {updateError}
-          </div>
+          <div className="error error-spacing">Error: {updateError}</div>
         )}
         {updateSuccess && (
-          <div style={{ color: "green", marginTop: "0.5em" }}>
-            Organization updated!
-          </div>
+          <div className="success-message">Organization updated!</div>
         )}
       </form>
 
@@ -231,6 +227,12 @@ const OrganizationDetailsPage: React.FC = () => {
             ))}
           </ul>
         )}
+      </div>
+      <div className="link-container">
+        <Link to={`/org/${id}/usage-cost`}>Usage Cost</Link>
+        <Link to={`/org/${id}/private-endpoint-config`}>
+          Private Endpoint Config
+        </Link>
       </div>
       <Link to="/">Back to Organizations</Link>
     </section>

--- a/example/src/pages/OrganizationListPage.tsx
+++ b/example/src/pages/OrganizationListPage.tsx
@@ -32,7 +32,6 @@ const OrganizationListPage: React.FC = () => {
       <button
         onClick={() => mutate()}
         className="refresh-button"
-        style={{ marginBottom: '1em' }}
         disabled={isValidating}
       >
         {isValidating ? 'Loading...' : 'Refresh'}

--- a/example/src/pages/OrganizationPrivateEndpointConfigPage.tsx
+++ b/example/src/pages/OrganizationPrivateEndpointConfigPage.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from "react";
+import "../App.css";
+import { useParams, Link } from "react-router-dom";
+import {
+  useOrganizationPrivateEndpointConfig,
+  ClickHouseAPIError,
+} from "clickhouse-cloud-react-hooks";
+import { useAtomValue } from "jotai";
+import { configAtom } from "../configAtoms";
+
+const OrganizationPrivateEndpointConfigPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const config = useAtomValue(configAtom);
+  const [cloudProvider, setCloudProvider] = useState("");
+  const [region, setRegion] = useState("");
+
+  const { data, error, isLoading, isValidating, mutate } =
+    useOrganizationPrivateEndpointConfig(
+      id || "",
+      config || { keyId: "", keySecret: "" },
+      {
+        cloudProvider: cloudProvider || undefined,
+        region: region || undefined,
+      }
+    );
+
+  if (!config) {
+    return (
+      <div>
+        <h2>Not configured</h2>
+        <p>
+          Please go to the <Link to="/config">Configuration</Link> page and
+          enter your credentials.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <section className="private-endpoint-config-section">
+      <h2>Private Endpoint Config</h2>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          mutate();
+        }}
+        className="form-inline"
+      >
+        <label>
+          Cloud Provider:
+          <input
+            type="text"
+            value={cloudProvider}
+            onChange={(e) => setCloudProvider(e.target.value)}
+            className="input-inline"
+          />
+        </label>
+        <label>
+          Region:
+          <input
+            type="text"
+            value={region}
+            onChange={(e) => setRegion(e.target.value)}
+            className="input-inline"
+          />
+        </label>
+        <button type="submit" disabled={isValidating}>
+          {isValidating ? "Loading..." : "Refresh"}
+        </button>
+      </form>
+      {isLoading ? (
+        <div>Loading private endpoint config...</div>
+      ) : error ? (
+        <div className="error">
+          {error instanceof ClickHouseAPIError ? (
+            <div>
+              <strong>ClickHouse API Error:</strong> {error.error}
+              <br />
+              <small>Status: {error.status}</small>
+            </div>
+          ) : (
+            <div>Error: {error.message}</div>
+          )}
+        </div>
+      ) : data ? (
+        <div>
+          <p>
+            <strong>Endpoint Service ID:</strong> {data.endpointServiceId}
+          </p>
+        </div>
+      ) : (
+        <div>No data</div>
+      )}
+      <p className="back-link">
+        <Link to={`/org/${id}`}>Back to details</Link>
+      </p>
+    </section>
+  );
+};
+
+export default OrganizationPrivateEndpointConfigPage;
+

--- a/example/src/pages/OrganizationUsageCostPage.tsx
+++ b/example/src/pages/OrganizationUsageCostPage.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from "react";
+import "../App.css";
+import { useParams, Link } from "react-router-dom";
+import {
+  useOrganizationUsageCost,
+  ClickHouseAPIError,
+} from "clickhouse-cloud-react-hooks";
+import { useAtomValue } from "jotai";
+import { configAtom } from "../configAtoms";
+
+const OrganizationUsageCostPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const config = useAtomValue(configAtom);
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  const { data, error, isLoading, isValidating, mutate } =
+    useOrganizationUsageCost(
+      id || "",
+      config || { keyId: "", keySecret: "" },
+      { startDate: startDate || undefined, endDate: endDate || undefined }
+    );
+
+  if (!config) {
+    return (
+      <div>
+        <h2>Not configured</h2>
+        <p>
+          Please go to the <Link to="/config">Configuration</Link> page and
+          enter your credentials.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <section className="usage-cost-section">
+      <h2>Usage Cost</h2>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          mutate();
+        }}
+        className="form-inline"
+      >
+        <label>
+          Start Date:
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="input-inline"
+          />
+        </label>
+        <label>
+          End Date:
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className="input-inline"
+          />
+        </label>
+        <button type="submit" disabled={isValidating}>
+          {isValidating ? "Loading..." : "Refresh"}
+        </button>
+      </form>
+      {isLoading ? (
+        <div>Loading usage cost...</div>
+      ) : error ? (
+        <div className="error">
+          {error instanceof ClickHouseAPIError ? (
+            <div>
+              <strong>ClickHouse API Error:</strong> {error.error}
+              <br />
+              <small>Status: {error.status}</small>
+            </div>
+          ) : (
+            <div>Error: {error.message}</div>
+          )}
+        </div>
+      ) : data ? (
+        <div>
+          <p>
+            <strong>Grand Total CHC:</strong> {data.grandTotalCHC}
+          </p>
+          <div>
+            <strong>Cost Record:</strong>
+            <div>
+              <strong>Date:</strong> {data.costs.date}
+            </div>
+            <div>
+              <strong>Entity Name:</strong> {data.costs.entityName}
+            </div>
+            <div>
+              <strong>Total CHC:</strong> {data.costs.totalCHC}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div>No data</div>
+      )}
+      <p className="back-link">
+        <Link to={`/org/${id}`}>Back to details</Link>
+      </p>
+    </section>
+  );
+};
+
+export default OrganizationUsageCostPage;
+

--- a/src/hooks/tests/useOrganizationPrivateEndpointConfig.test.tsx
+++ b/src/hooks/tests/useOrganizationPrivateEndpointConfig.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockFetch } from "../../utils/testUtils";
+import { render } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
+import React from "react";
+import { useOrganizationPrivateEndpointConfig } from "../useOrganizations";
+
+const organizationId = "550e8400-e29b-41d4-a716-446655440001";
+
+const mockPrivateEndpointConfigResponse = {
+  status: 200,
+  requestId: "550e8400-e29b-41d4-a716-446655440000",
+  result: {
+    endpointServiceId: "svc-123",
+  },
+};
+
+const config = {
+  keyId: "test-key-id",
+  keySecret: "test-key-secret",
+  baseUrl: "https://api.clickhouse.cloud",
+};
+
+const errorConfig = {
+  keyId: "error-key-id",
+  keySecret: "error-key-secret",
+  baseUrl: "https://api.clickhouse.cloud",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetch<typeof mockPrivateEndpointConfigResponse>({
+    response: mockPrivateEndpointConfigResponse,
+  });
+});
+
+describe("useOrganizationPrivateEndpointConfig", () => {
+  function HookTest({
+    onResult,
+    organizationId: orgId,
+    config: testConfig,
+    params,
+  }: {
+    onResult: (result: ReturnType<typeof useOrganizationPrivateEndpointConfig>) => void;
+    organizationId: string;
+    config: typeof config;
+    params?: { cloudProvider?: string; region?: string };
+  }) {
+    const result = useOrganizationPrivateEndpointConfig(orgId, testConfig, params);
+    React.useEffect(() => {
+      onResult(result);
+    }, [result, onResult]);
+    return null;
+  }
+
+  it("should fetch and return private endpoint config", async () => {
+    let hookResult:
+      | ReturnType<typeof useOrganizationPrivateEndpointConfig>
+      | undefined;
+    render(
+      <HookTest
+        organizationId={organizationId}
+        config={config}
+        params={{ cloudProvider: "aws", region: "us-east-1" }}
+        onResult={(r) => (hookResult = r)}
+      />
+    );
+    await waitFor(() => expect(hookResult?.isLoading).toBe(false));
+    expect(hookResult?.data).toEqual(
+      mockPrivateEndpointConfigResponse.result
+    );
+    expect(hookResult?.error).toBeUndefined();
+    expect(hookResult?.response).toEqual(
+      mockPrivateEndpointConfigResponse
+    );
+  });
+
+  it("should handle API error", async () => {
+    mockFetch<{ status: number; error: string }>({
+      response: { status: 404, error: "Not Found" },
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    });
+    let hookResult:
+      | ReturnType<typeof useOrganizationPrivateEndpointConfig>
+      | undefined;
+    render(
+      <HookTest
+        organizationId={organizationId}
+        config={errorConfig}
+        onResult={(r) => (hookResult = r)}
+      />
+    );
+    await waitFor(() => expect(hookResult?.isLoading).toBe(false));
+    expect(hookResult?.data).toBeUndefined();
+    expect(hookResult?.error).toBeDefined();
+  });
+});
+

--- a/src/hooks/tests/useOrganizationUsageCost.test.tsx
+++ b/src/hooks/tests/useOrganizationUsageCost.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockFetch } from "../../utils/testUtils";
+import { render } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
+import React from "react";
+import { useOrganizationUsageCost } from "../useOrganizations";
+
+const organizationId = "550e8400-e29b-41d4-a716-446655440001";
+
+const mockUsageCostResponse = {
+  status: 200,
+  requestId: "550e8400-e29b-41d4-a716-446655440000",
+  result: {
+    grandTotalCHC: 100,
+    costs: {
+      dataWarehouseId: "550e8400-e29b-41d4-a716-446655440001",
+      serviceId: "550e8400-e29b-41d4-a716-446655440002",
+      date: "2024-01-01",
+      entityType: "datawarehouse",
+      entityId: "550e8400-e29b-41d4-a716-446655440001",
+      entityName: "Test Data Warehouse",
+      metrics: {
+        storageCHC: 10,
+      },
+      totalCHC: 100,
+      locked: false,
+    },
+  },
+};
+
+const config = {
+  keyId: "test-key-id",
+  keySecret: "test-key-secret",
+  baseUrl: "https://api.clickhouse.cloud",
+};
+
+const errorConfig = {
+  keyId: "error-key-id",
+  keySecret: "error-key-secret",
+  baseUrl: "https://api.clickhouse.cloud",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetch<typeof mockUsageCostResponse>({
+    response: mockUsageCostResponse,
+  });
+});
+
+describe("useOrganizationUsageCost", () => {
+  function HookTest({
+    onResult,
+    organizationId: orgId,
+    config: testConfig,
+    params,
+  }: {
+    onResult: (result: ReturnType<typeof useOrganizationUsageCost>) => void;
+    organizationId: string;
+    config: typeof config;
+    params?: { startDate?: string; endDate?: string };
+  }) {
+    const result = useOrganizationUsageCost(orgId, testConfig, params);
+    React.useEffect(() => {
+      onResult(result);
+    }, [result, onResult]);
+    return null;
+  }
+
+  it("should fetch and return usage cost data", async () => {
+    let hookResult: ReturnType<typeof useOrganizationUsageCost> | undefined;
+    render(
+      <HookTest
+        organizationId={organizationId}
+        config={config}
+        params={{ startDate: "2024-01-01", endDate: "2024-01-02" }}
+        onResult={(r) => (hookResult = r)}
+      />
+    );
+    await waitFor(() => expect(hookResult?.isLoading).toBe(false));
+    expect(hookResult?.data).toEqual(mockUsageCostResponse.result);
+    expect(hookResult?.error).toBeUndefined();
+    expect(hookResult?.response).toEqual(mockUsageCostResponse);
+  });
+
+  it("should handle API error", async () => {
+    mockFetch<{ status: number; error: string }>({
+      response: { status: 500, error: "Internal Server Error" },
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+    let hookResult: ReturnType<typeof useOrganizationUsageCost> | undefined;
+    render(
+      <HookTest
+        organizationId={organizationId}
+        config={errorConfig}
+        onResult={(r) => (hookResult = r)}
+      />
+    );
+    await waitFor(() => expect(hookResult?.isLoading).toBe(false));
+    expect(hookResult?.data).toBeUndefined();
+    expect(hookResult?.error).toBeDefined();
+  });
+});
+


### PR DESCRIPTION
## Summary
- test organization usage cost hook success and error cases
- test organization private endpoint config hook success and error cases
- add example pages for organization usage cost and private endpoint config hooks
- move example app inline styles into dedicated CSS files

## Testing
- `yarn lint` (fails: Unexpected any and unused var in unrelated files)
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_689637dc9a588324bb503aeaa10167ae