### PR TITLE
Add Prometheus metrics hooks tests and examples

### DIFF
--- a/example/src/pages/OrganizationDetailsPage.tsx
+++ b/example/src/pages/OrganizationDetailsPage.tsx
@@ -4,10 +4,45 @@ import { useParams, Link } from "react-router-dom";
 import {
   useOrganization,
   useUpdateOrganization,
+  useOrganizationPrometheusMetrics,
+  useServicePrometheusMetrics,
   ClickHouseAPIError,
+  ClickHouseConfig,
 } from "clickhouse-cloud-react-hooks";
 import { useAtomValue } from "jotai";
 import { configAtom } from "../configAtoms";
+
+function ServiceMetrics({
+  organizationId,
+  serviceId,
+  config,
+  filtered,
+}: {
+  organizationId: string;
+  serviceId: string;
+  config: ClickHouseConfig;
+  filtered: boolean;
+}) {
+  const { data, error, isLoading } = useServicePrometheusMetrics(
+    organizationId,
+    serviceId,
+    config,
+    filtered
+  );
+  if (isLoading) {
+    return <div>Loading service metrics...</div>;
+  }
+  if (error) {
+    return (
+      <div className="error">
+        {error instanceof ClickHouseAPIError
+          ? `ClickHouse API Error: ${error.error}`
+          : `Error: ${(error as Error).message}`}
+      </div>
+    );
+  }
+  return <pre>{data}</pre>;
+}
 
 const OrganizationDetailsPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -32,6 +67,21 @@ const OrganizationDetailsPage: React.FC = () => {
   const [updateLoading, setUpdateLoading] = useState(false);
   const [updateError, setUpdateError] = useState<string | null>(null);
   const [updateSuccess, setUpdateSuccess] = useState(false);
+
+  const [filterOrgMetrics, setFilterOrgMetrics] = useState(false);
+  const {
+    data: orgMetrics,
+    error: orgMetricsError,
+    isLoading: orgMetricsLoading,
+  } = useOrganizationPrometheusMetrics(
+    id || "",
+    config || { keyId: "", keySecret: "" },
+    filterOrgMetrics
+  );
+
+  const [serviceIdInput, setServiceIdInput] = useState("");
+  const [serviceId, setServiceId] = useState<string | null>(null);
+  const [filterServiceMetrics, setFilterServiceMetrics] = useState(false);
 
   // Set initial editName when organization loads
   useEffect(() => {
@@ -230,6 +280,63 @@ const OrganizationDetailsPage: React.FC = () => {
               </li>
             ))}
           </ul>
+        )}
+      </div>
+      <div>
+        <h3>Organization Prometheus Metrics</h3>
+        <label>
+          <input
+            type="checkbox"
+            checked={filterOrgMetrics}
+            onChange={(e) => setFilterOrgMetrics(e.target.checked)}
+            style={{ marginRight: "0.5em" }}
+          />
+          Filter metrics
+        </label>
+        {orgMetricsLoading ? (
+          <div>Loading metrics...</div>
+        ) : orgMetricsError ? (
+          <div className="error">
+            {orgMetricsError instanceof ClickHouseAPIError
+              ? `ClickHouse API Error: ${orgMetricsError.error}`
+              : `Error: ${(orgMetricsError as Error).message}`}
+          </div>
+        ) : (
+          <pre>{orgMetrics}</pre>
+        )}
+      </div>
+      <div>
+        <h3>Service Prometheus Metrics</h3>
+        <input
+          type="text"
+          placeholder="Service ID"
+          value={serviceIdInput}
+          onChange={(e) => setServiceIdInput(e.target.value)}
+          style={{ marginRight: "0.5em" }}
+        />
+        <label style={{ marginRight: "0.5em" }}>
+          <input
+            type="checkbox"
+            checked={filterServiceMetrics}
+            onChange={(e) => setFilterServiceMetrics(e.target.checked)}
+            style={{ marginRight: "0.25em" }}
+          />
+          Filter
+        </label>
+        <button
+          onClick={() => setServiceId(serviceIdInput)}
+          disabled={serviceIdInput.trim() === ""}
+          style={{ marginRight: "0.5em" }}
+        >
+          Load Metrics
+        </button>
+        {serviceId && config && (
+          <ServiceMetrics
+            organizationId={id || ""}
+            serviceId={serviceId}
+            config={config}
+            filtered={filterServiceMetrics}
+          />
         )}
       </div>
       <Link to="/">Back to Organizations</Link>

--- a/src/hooks/tests/usePrometheusMetrics.test.tsx
+++ b/src/hooks/tests/usePrometheusMetrics.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockFetch } from "../../utils/testUtils";
+import { render } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
+import React from "react";
+import {
+  useOrganizationPrometheusMetrics,
+  useServicePrometheusMetrics,
+} from "../usePrometheusMetrics";
+
+const metricsResponse = "# HELP some_metric\n# TYPE some_metric counter";
+
+const config = {
+  keyId: "test-key-id",
+  keySecret: "test-key-secret",
+  baseUrl: "https://api.clickhouse.cloud",
+};
+
+describe("useOrganizationPrometheusMetrics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch({ response: metricsResponse });
+  });
+
+  function HookTest({
+    onResult,
+    filteredMetrics,
+  }: {
+    onResult: (
+      result: ReturnType<typeof useOrganizationPrometheusMetrics>
+    ) => void;
+    filteredMetrics?: boolean;
+  }) {
+    const result = useOrganizationPrometheusMetrics(
+      "org1",
+      config,
+      filteredMetrics
+    );
+    React.useEffect(() => {
+      onResult(result);
+    }, [result, onResult]);
+    return null;
+  }
+
+  it("fetches organization metrics", async () => {
+    let hookResult:
+      | ReturnType<typeof useOrganizationPrometheusMetrics>
+      | undefined;
+    render(
+      <HookTest
+        filteredMetrics
+        onResult={(r) => (hookResult = r)}
+      />
+    );
+    await waitFor(() => expect(hookResult?.isLoading).toBe(false));
+    expect(hookResult?.data).toBe(metricsResponse);
+    expect(hookResult?.error).toBeUndefined();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.clickhouse.cloud/v1/organizations/org1/prometheus?filtered_metrics=true",
+      expect.any(Object)
+    );
+  });
+
+  it("handles API error", async () => {
+    mockFetch<{ status: number; error: string }>({
+      response: { status: 404, error: "Not found" },
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      text: JSON.stringify({ status: 404, error: "Not found" }),
+    });
+    let hookResult:
+      | ReturnType<typeof useOrganizationPrometheusMetrics>
+      | undefined;
+    render(
+      <HookTest onResult={(r) => (hookResult = r)} />
+    );
+    await waitFor(() => expect(hookResult?.isLoading).toBe(false));
+    expect(hookResult?.data).toBeUndefined();
+    expect(hookResult?.error).toBeDefined();
+  });
+});
+
+describe("useServicePrometheusMetrics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch({ response: metricsResponse });
+  });
+
+  function HookTest({
+    onResult,
+    filteredMetrics,
+  }: {
+    onResult: (result: ReturnType<typeof useServicePrometheusMetrics>) => void;
+    filteredMetrics?: boolean;
+  }) {
+    const result = useServicePrometheusMetrics(
+      "org1",
+      "svc1",
+      config,
+      filteredMetrics
+    );
+    React.useEffect(() => {
+      onResult(result);
+    }, [result, onResult]);
+    return null;
+  }
+
+  it("fetches service metrics", async () => {
+    let hookResult: ReturnType<typeof useServicePrometheusMetrics> | undefined;
+    render(
+      <HookTest
+        filteredMetrics
+        onResult={(r) => (hookResult = r)}
+      />
+    );
+    await waitFor(() => expect(hookResult?.isLoading).toBe(false));
+    expect(hookResult?.data).toBe(metricsResponse);
+    expect(hookResult?.error).toBeUndefined();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.clickhouse.cloud/v1/organizations/org1/services/svc1/prometheus?filtered_metrics=true",
+      expect.any(Object)
+    );
+  });
+
+  it("handles API error", async () => {
+    mockFetch<{ status: number; error: string }>({
+      response: { status: 500, error: "Server error" },
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      text: JSON.stringify({ status: 500, error: "Server error" }),
+    });
+    let hookResult: ReturnType<typeof useServicePrometheusMetrics> | undefined;
+    render(<HookTest onResult={(r) => (hookResult = r)} />);
+    await waitFor(() => expect(hookResult?.isLoading).toBe(false));
+    expect(hookResult?.data).toBeUndefined();
+    expect(hookResult?.error).toBeDefined();
+  });
+});
+

--- a/src/hooks/usePrometheusMetrics.ts
+++ b/src/hooks/usePrometheusMetrics.ts
@@ -5,11 +5,17 @@ import type { ClickHouseConfig } from "../api/fetcher";
 // Fetch organization-level Prometheus metrics
 export function useOrganizationPrometheusMetrics(
   organizationId: string,
-  config: ClickHouseConfig
+  config: ClickHouseConfig,
+  filteredMetrics?: boolean
 ) {
+  const query =
+    filteredMetrics !== undefined
+      ? `?filtered_metrics=${filteredMetrics}`
+      : "";
   const { data, error, isLoading } = useSWR(
-    [`/v1/organizations/${organizationId}/prometheus`, config],
-    ([url, cfg]: [string, ClickHouseConfig]) => fetcher(url, cfg)
+    [`/v1/organizations/${organizationId}/prometheus${query}`, config],
+    ([url, cfg]: [string, ClickHouseConfig]) =>
+      fetcher<string>(url, cfg, undefined, "text")
   );
   return { data, error, isLoading };
 }
@@ -18,14 +24,20 @@ export function useOrganizationPrometheusMetrics(
 export function useServicePrometheusMetrics(
   organizationId: string,
   serviceId: string,
-  config: ClickHouseConfig
+  config: ClickHouseConfig,
+  filteredMetrics?: boolean
 ) {
+  const query =
+    filteredMetrics !== undefined
+      ? `?filtered_metrics=${filteredMetrics}`
+      : "";
   const { data, error, isLoading } = useSWR(
     [
-      `/v1/organizations/${organizationId}/services/${serviceId}/prometheus`,
+      `/v1/organizations/${organizationId}/services/${serviceId}/prometheus${query}`,
       config,
     ],
-    ([url, cfg]: [string, ClickHouseConfig]) => fetcher(url, cfg)
+    ([url, cfg]: [string, ClickHouseConfig]) =>
+      fetcher<string>(url, cfg, undefined, "text")
   );
   return { data, error, isLoading };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ export * from "./hooks/useServices";
 export * from "./hooks/useBackups";
 export * from "./hooks/useUserManagement";
 export * from "./hooks/useClickpipesReversePrivateEndpoints";
+export * from "./hooks/usePrometheusMetrics";
 
 // Export schemas and types
 export * from "./schemas/schemas";

--- a/src/schemas/schemas.test.ts
+++ b/src/schemas/schemas.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { 
-  OrganizationSchema, 
+  OrganizationSchema,
   OrganizationsResponseSchema,
   ActivitySchema,
-  ActivitiesResponseSchema,
   UsageCostSchema,
   ClickHouseErrorResponseSchema
 } from './schemas';


### PR DESCRIPTION
## Summary
- handle text responses in fetcher to support metrics endpoints
- add optional `filteredMetrics` query to Prometheus hooks and export them
- demonstrate Prometheus hooks in example app and add unit tests

## Testing
- `yarn lint` (fails: Unexpected any in existing files)
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689639908e788324ae6b09108803b640