### PR TITLE
Fix merge errors causing lint failures

### DIFF
--- a/example/src/pages/OrganizationDetailsPage.tsx
+++ b/example/src/pages/OrganizationDetailsPage.tsx
@@ -643,121 +643,125 @@ const OrganizationDetailsPage: React.FC = () => {
             )}
           </div>
         ) : activities && activities.length > 0 ? (
-          <ul>
-            {activities.map((act: Activity) => (
-              <li key={act.id}>
-                <Link to={`/org/${id}/activities/${act.id}`}>
-                  {act.type} - {new Date(act.createdAt).toLocaleString()}
-                </Link>
-      <section className="mt-1">
-        <h3>Services</h3>
-        <button
-          onClick={() => servicesMutate()}
-          className="refresh-button mb-1"
-          disabled={servicesValidating}
-        >
-          {servicesValidating ? "Loading..." : "Refresh"}
-        </button>
-        {servicesLoading ? (
-          <div>Loading services...</div>
-        ) : servicesError ? (
-          <div className="error">
-            {servicesError instanceof ClickHouseAPIError
-              ? servicesError.error
-              : String(servicesError)}
-          </div>
-        ) : services && services.length > 0 ? (
-          <ul>
-            {services.map((svc) => (
-              <li key={svc.id}>
-                <Link to={`/org/${id}/service/${svc.id}`}>{svc.name}</Link>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <div>No activities found</div>
-        )}
-      </div>
-          <div>No services found</div>
-        )}
-        <form
-          onSubmit={async (e) => {
-            e.preventDefault();
-            setCreateServiceError(null);
-            try {
-              await createService({
-                name: newServiceName,
-                provider: newServiceProvider,
-                region: newServiceRegion,
-                tier: newServiceTier,
-              });
-              setNewServiceName("");
-              setNewServiceProvider("");
-              setNewServiceRegion("");
-              setNewServiceTier("");
-              servicesMutate();
-            } catch (err: unknown) {
-              setCreateServiceError(
-                err && typeof err === "object" && "message" in err
-                  ? String((err as { message?: unknown }).message)
-                  : "Failed to create service"
-              );
-            }
-          }}
-          className="mt-1"
-        >
-          <h4>Create Service</h4>
-          <div>
-            <input
-              type="text"
-              placeholder="Name"
-              value={newServiceName}
-              onChange={(e) => setNewServiceName(e.target.value)}
-              className="mr-05"
-            />
-            <input
-              type="text"
-              placeholder="Provider"
-              value={newServiceProvider}
-              onChange={(e) => setNewServiceProvider(e.target.value)}
-              className="mr-05"
-            />
-            <input
-              type="text"
-              placeholder="Region"
-              value={newServiceRegion}
-              onChange={(e) => setNewServiceRegion(e.target.value)}
-              className="mr-05"
-            />
-            <input
-              type="text"
-              placeholder="Tier"
-              value={newServiceTier}
-              onChange={(e) => setNewServiceTier(e.target.value)}
-              className="mr-05"
-            />
-            <button
-              type="submit"
-              disabled={
-                !newServiceName ||
-                !newServiceProvider ||
-                !newServiceRegion ||
-                !newServiceTier
-              }
-            >
-              Create
-            </button>
-          </div>
-          {createServiceError && (
-            <div className="error mt-05">Error: {createServiceError}</div>
+            <ul>
+              {activities.map((act: Activity) => (
+                <li key={act.id}>
+                  <Link to={`/org/${id}/activities/${act.id}`}>
+                    {act.type} - {new Date(act.createdAt).toLocaleString()}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div>No activities found</div>
           )}
-        </form>
-      </section>
-      <div>
-        <h3>Organization Prometheus Metrics</h3>
-        <label>
-          <input
-            type="checkbox"
+        </div>
+        <section className="mt-1">
+          <h3>Services</h3>
+          <button
+            onClick={() => servicesMutate()}
+            className="refresh-button mb-1"
+            disabled={servicesValidating}
+          >
+            {servicesValidating ? "Loading..." : "Refresh"}
+          </button>
+          {servicesLoading ? (
+            <div>Loading services...</div>
+          ) : servicesError ? (
+            <div className="error">
+              {servicesError instanceof ClickHouseAPIError
+                ? servicesError.error
+                : String(servicesError)}
+            </div>
+          ) : services && services.length > 0 ? (
+            <ul>
+              {services.map((svc) => (
+                <li key={svc.id}>
+                  <Link to={`/org/${id}/service/${svc.id}`}>{svc.name}</Link>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div>No services found</div>
+          )}
+          <form
+            onSubmit={async (e) => {
+              e.preventDefault();
+              setCreateServiceError(null);
+              try {
+                await createService({
+                  name: newServiceName,
+                  provider: newServiceProvider,
+                  region: newServiceRegion,
+                  tier: newServiceTier,
+                });
+                setNewServiceName("");
+                setNewServiceProvider("");
+                setNewServiceRegion("");
+                setNewServiceTier("");
+                servicesMutate();
+              } catch (err: unknown) {
+                setCreateServiceError(
+                  err && typeof err === "object" && "message" in err
+                    ? String((err as { message?: unknown }).message)
+                    : "Failed to create service"
+                );
+              }
+            }}
+            className="mt-1"
+          >
+            <h4>Create Service</h4>
+            <div>
+              <input
+                type="text"
+                placeholder="Name"
+                value={newServiceName}
+                onChange={(e) => setNewServiceName(e.target.value)}
+                className="mr-05"
+              />
+              <input
+                type="text"
+                placeholder="Provider"
+                value={newServiceProvider}
+                onChange={(e) => setNewServiceProvider(e.target.value)}
+                className="mr-05"
+              />
+              <input
+                type="text"
+                placeholder="Region"
+                value={newServiceRegion}
+                onChange={(e) => setNewServiceRegion(e.target.value)}
+                className="mr-05"
+              />
+              <input
+                type="text"
+                placeholder="Tier"
+                value={newServiceTier}
+                onChange={(e) => setNewServiceTier(e.target.value)}
+                className="mr-05"
+              />
+              <button
+                type="submit"
+                disabled={
+                  !newServiceName ||
+                  !newServiceProvider ||
+                  !newServiceRegion ||
+                  !newServiceTier
+                }
+              >
+                Create
+              </button>
+            </div>
+            {createServiceError && (
+              <div className="error mt-05">Error: {createServiceError}</div>
+            )}
+          </form>
+        </section>
+        <div>
+          <h3>Organization Prometheus Metrics</h3>
+          <label>
+            <input
+              type="checkbox"
             checked={filterOrgMetrics}
             onChange={(e) => setFilterOrgMetrics(e.target.checked)}
             style={{ marginRight: "0.5em" }}

--- a/src/hooks/useInvitations.ts
+++ b/src/hooks/useInvitations.ts
@@ -14,12 +14,6 @@ export function useCreateInvitation(
   organizationId: string,
   config: ClickHouseConfig
 ) {
-  const createInvitation = async (invitationData: unknown) => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
   const createInvitation = async (invitationData: {
     email: string;
     role: "admin" | "developer";


### PR DESCRIPTION
## Summary
- close Activities list correctly in OrganizationDetailsPage and restore Services section
- clean up duplicated logic in useInvitations hook

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6898ae1453108324bef1139d26bd0f00