### PR TITLE
Refactor hooks with resource factory

### DIFF
--- a/example/src/pages/ServiceBackupsPage.tsx
+++ b/example/src/pages/ServiceBackupsPage.tsx
@@ -34,11 +34,28 @@ const ServiceBackupsPage: React.FC = () => {
     serviceId || "",
     config || { keyId: "", keySecret: "" }
   );
-  const { deleteBackup } = useDeleteServiceBackup(
-    id || "",
-    serviceId || "",
-    config || { keyId: "", keySecret: "" }
-  );
+  const DeleteButton: React.FC<{ backupId: string }> = ({ backupId }) => {
+    const { deleteBackup } = useDeleteServiceBackup(
+      id || "",
+      serviceId || "",
+      backupId,
+      config || { keyId: "", keySecret: "" }
+    );
+    return (
+      <button
+        onClick={async () => {
+          try {
+            await deleteBackup();
+            await mutateBackups();
+          } catch {
+            // ignore error
+          }
+        }}
+      >
+        Delete
+      </button>
+    );
+  };
 
   const [period, setPeriod] = useState("");
   const [retention, setRetention] = useState("");
@@ -165,18 +182,7 @@ const ServiceBackupsPage: React.FC = () => {
               <div>
                 <strong>{b.id}</strong> - {b.status}
               </div>
-              <button
-                onClick={async () => {
-                  try {
-                    await deleteBackup(b.id);
-                    await mutateBackups();
-                  } catch {
-                    // ignore error
-                  }
-                }}
-              >
-                Delete
-              </button>
+              <DeleteButton backupId={b.id} />
             </li>
           ))}
         </ul>

--- a/src/hooks/_core.ts
+++ b/src/hooks/_core.ts
@@ -1,0 +1,25 @@
+import type { ClickHouseConfig } from "../api/fetcher";
+
+export const swrKey = (url: string, cfg: ClickHouseConfig) =>
+  `${url}:${cfg.baseUrl}:${cfg.keyId}`;
+
+export async function authedJson<T>(
+  cfg: ClickHouseConfig,
+  url: string,
+  init?: RequestInit,
+  asText = false
+): Promise<T> {
+  const { keyId, keySecret, baseUrl = "https://api.clickhouse.cloud" } = cfg;
+  const auth = btoa(`${keyId}:${keySecret}`);
+  const res = await fetch(`${baseUrl}${url}`, {
+    ...init,
+    headers: {
+      Authorization: `Basic ${auth}`,
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return (asText ? (res.text() as unknown as T) : res.json()) as Promise<T>;
+}
+

--- a/src/hooks/createResourceHooks.ts
+++ b/src/hooks/createResourceHooks.ts
@@ -1,0 +1,95 @@
+import useSWR, { mutate } from "swr";
+import { z } from "zod";
+import { swrKey, authedJson } from "./_core";
+import type { ClickHouseConfig } from "../api/fetcher";
+
+type PathFn<C> = (ctx: C) => string;
+
+type ListSpec<TList> = {
+  path: PathFn<any>;
+  schema: z.ZodSchema<TList>;
+};
+
+type ItemSpec<TItem> = {
+  path: PathFn<any>;
+  schema: z.ZodSchema<TItem>;
+};
+
+type ActionSpec<TResp> = {
+  method: "POST" | "PATCH" | "DELETE" | "PUT";
+  path: PathFn<any>;
+  schema?: z.ZodSchema<TResp>;
+  asText?: boolean;
+};
+
+type ResourceSpec<TList, TItem> = {
+  list: ListSpec<TList>;
+  item: ItemSpec<TItem>;
+  create?: ActionSpec<TItem>;
+  update?: ActionSpec<TItem>;
+  remove?: ActionSpec<any>;
+  actions?: Record<string, ActionSpec<any>>;
+  invalidate?: (ctx: any) => string[];
+};
+
+export function createResourceHooks<
+  TList extends { result: any },
+  TItem extends { result: any },
+  Ctx
+>(spec: ResourceSpec<TList, TItem>) {
+  function useList(ctx: Ctx, cfg: ClickHouseConfig) {
+    const url = spec.list.path(ctx);
+    const { data, error, isLoading, isValidating, mutate } = useSWR(
+      swrKey(url, cfg),
+      () => authedJson<TList>(cfg, url).then(spec.list.schema.parse)
+    );
+    return { data: data?.result, response: data, error, isLoading, isValidating, mutate };
+  }
+
+  function useOne(ctx: Ctx, cfg: ClickHouseConfig) {
+    const url = spec.item.path(ctx);
+    const { data, error, isLoading, isValidating, mutate } = useSWR(
+      swrKey(url, cfg),
+      () => authedJson<TItem>(cfg, url).then(spec.item.schema.parse)
+    );
+    return { data: data?.result, response: data, error, isLoading, isValidating, mutate };
+  }
+
+  function makeMutation<TResp>(action: ActionSpec<TResp> | undefined) {
+    return (ctx: Ctx, cfg: ClickHouseConfig) => {
+      if (!action) return undefined as any;
+      return async (body?: unknown) => {
+        const url = action.path(ctx);
+        const resp = await authedJson<any>(
+          cfg,
+          url,
+          { method: action.method, body: body ? JSON.stringify(body) : undefined },
+          action.asText
+        );
+        const parsed = action.schema ? action.schema.parse(resp) : resp;
+        const keys = spec.invalidate
+          ? spec.invalidate(ctx)
+          : [spec.list.path(ctx), spec.item.path(ctx)];
+        await Promise.all(keys.map((k) => mutate(swrKey(k, cfg))));
+        return parsed?.result ?? parsed;
+      };
+    };
+  }
+
+  const useCreate = makeMutation(spec.create);
+  const useUpdate = makeMutation(spec.update);
+  const useDelete = makeMutation(spec.remove);
+
+  function useActions(ctx: Ctx, cfg: ClickHouseConfig) {
+    const result: Record<string, any> = {};
+    for (const [name, act] of Object.entries(spec.actions ?? {})) {
+      result[name] = makeMutation(act)(ctx, cfg);
+    }
+    return result as {
+      [K in keyof typeof spec.actions]: ReturnType<ReturnType<typeof makeMutation>>;
+    };
+  }
+
+  return { useList, useOne, useCreate, useUpdate, useDelete, useActions };
+}
+

--- a/src/hooks/createTextGetter.ts
+++ b/src/hooks/createTextGetter.ts
@@ -1,0 +1,14 @@
+import useSWR from "swr";
+import type { ClickHouseConfig } from "../api/fetcher";
+import { swrKey, authedJson } from "./_core";
+
+export function createTextGetter<Ctx>(path: (ctx: Ctx) => string) {
+  return function useText(ctx: Ctx, cfg: ClickHouseConfig) {
+    const url = path(ctx);
+    const { data, error, isLoading } = useSWR(swrKey(url, cfg), () =>
+      authedJson<string>(cfg, url, undefined, true)
+    );
+    return { data, error, isLoading };
+  };
+}
+

--- a/src/hooks/resources/apiKeys.ts
+++ b/src/hooks/resources/apiKeys.ts
@@ -1,0 +1,25 @@
+import { createResourceHooks } from "../createResourceHooks";
+import {
+  ApiKeysResponseSchema,
+  ApiKeyResponseSchema,
+  ApiKeyCreateResponseSchema,
+  ClickHouseBaseResponseSchema,
+} from "../../schemas/schemas";
+
+interface Ctx {
+  organizationId: string;
+  keyId?: string;
+}
+const base = (c: Ctx) => `/v1/organizations/${c.organizationId}/keys`;
+
+export const apiKeyHooks = createResourceHooks(
+  {
+    list: { path: base, schema: ApiKeysResponseSchema },
+    item: { path: (c: Ctx) => `${base(c)}/${c.keyId}`, schema: ApiKeyResponseSchema },
+    create: { method: "POST", path: base, schema: ApiKeyCreateResponseSchema },
+    update: { method: "PATCH", path: (c: Ctx) => `${base(c)}/${c.keyId}`, schema: ApiKeyResponseSchema },
+    remove: { method: "DELETE", path: (c: Ctx) => `${base(c)}/${c.keyId}`, schema: ClickHouseBaseResponseSchema },
+    invalidate: (c: Ctx) => [base(c), `${base(c)}/${c.keyId}`],
+  }
+);
+

--- a/src/hooks/resources/backups.ts
+++ b/src/hooks/resources/backups.ts
@@ -1,0 +1,28 @@
+import { createResourceHooks } from "../createResourceHooks";
+import {
+  BackupsResponseSchema,
+  BackupResponseSchema,
+  BackupConfigurationResponseSchema,
+} from "../../schemas/schemas";
+
+interface Ctx {
+  organizationId: string;
+  serviceId: string;
+  backupId?: string;
+}
+const base = (c: Ctx) => `/v1/organizations/${c.organizationId}/services/${c.serviceId}`;
+
+export const serviceBackupsHooks = createResourceHooks({
+  list: { path: (c: Ctx) => `${base(c)}/backups`, schema: BackupsResponseSchema },
+  item: { path: (c: Ctx) => `${base(c)}/backups/${c.backupId}`, schema: BackupResponseSchema },
+  remove: { method: "DELETE", path: (c: Ctx) => `${base(c)}/backups/${c.backupId}` },
+  invalidate: (c: Ctx) => [`${base(c)}/backups`, `${base(c)}/backups/${c.backupId}`],
+});
+
+export const serviceBackupConfigurationHooks = createResourceHooks({
+  list: { path: (c: Ctx) => `${base(c)}/backupConfiguration`, schema: BackupConfigurationResponseSchema },
+  item: { path: (c: Ctx) => `${base(c)}/backupConfiguration`, schema: BackupConfigurationResponseSchema },
+  update: { method: "PATCH", path: (c: Ctx) => `${base(c)}/backupConfiguration`, schema: BackupConfigurationResponseSchema },
+  invalidate: (c: Ctx) => [`${base(c)}/backupConfiguration`],
+});
+

--- a/src/hooks/resources/clickpipes.ts
+++ b/src/hooks/resources/clickpipes.ts
@@ -1,0 +1,29 @@
+import { createResourceHooks } from "../createResourceHooks";
+import {
+  ClickPipesResponseSchema,
+  ClickPipeResponseSchema,
+  ClickHouseBaseResponseSchema,
+} from "../../schemas/schemas";
+
+interface Ctx {
+  organizationId: string;
+  serviceId: string;
+  clickPipeId?: string;
+}
+const base = (c: Ctx) => `/v1/organizations/${c.organizationId}/services/${c.serviceId}/clickpipes`;
+
+export const clickpipeHooks = createResourceHooks(
+  {
+    list: { path: base, schema: ClickPipesResponseSchema },
+    item: { path: (c: Ctx) => `${base(c)}/${c.clickPipeId}`, schema: ClickPipeResponseSchema },
+    create: { method: "POST", path: base, schema: ClickPipeResponseSchema },
+    update: { method: "PATCH", path: (c: Ctx) => `${base(c)}/${c.clickPipeId}`, schema: ClickPipeResponseSchema },
+    remove: { method: "DELETE", path: (c: Ctx) => `${base(c)}/${c.clickPipeId}`, schema: ClickHouseBaseResponseSchema },
+    actions: {
+      updateScaling: { method: "PATCH", path: (c: Ctx) => `${base(c)}/${c.clickPipeId}/scaling`, schema: ClickPipeResponseSchema },
+      updateState: { method: "PATCH", path: (c: Ctx) => `${base(c)}/${c.clickPipeId}/state`, schema: ClickPipeResponseSchema },
+    },
+    invalidate: (c: Ctx) => [base(c), `${base(c)}/${c.clickPipeId}`],
+  }
+);
+

--- a/src/hooks/resources/clickpipesReversePrivateEndpoints.ts
+++ b/src/hooks/resources/clickpipesReversePrivateEndpoints.ts
@@ -1,0 +1,22 @@
+import { createResourceHooks } from "../createResourceHooks";
+import {
+  ReversePrivateEndpointsResponseSchema,
+  ReversePrivateEndpointResponseSchema,
+  ClickHouseBaseResponseSchema,
+} from "../../schemas/schemas";
+
+interface Ctx {
+  organizationId: string;
+  serviceId: string;
+  endpointId?: string;
+}
+const base = (c: Ctx) => `/v1/organizations/${c.organizationId}/services/${c.serviceId}/clickpipesReversePrivateEndpoints`;
+
+export const clickpipesRpeHooks = createResourceHooks({
+  list: { path: base, schema: ReversePrivateEndpointsResponseSchema },
+  item: { path: (c: Ctx) => `${base(c)}/${c.endpointId}`, schema: ReversePrivateEndpointResponseSchema },
+  create: { method: "POST", path: base, schema: ReversePrivateEndpointResponseSchema },
+  remove: { method: "DELETE", path: (c: Ctx) => `${base(c)}/${c.endpointId}`, schema: ClickHouseBaseResponseSchema },
+  invalidate: (c: Ctx) => [base(c), `${base(c)}/${c.endpointId}`],
+});
+

--- a/src/hooks/resources/invitations.ts
+++ b/src/hooks/resources/invitations.ts
@@ -1,0 +1,21 @@
+import { createResourceHooks } from "../createResourceHooks";
+import {
+  InvitationsResponseSchema,
+  InvitationResponseSchema,
+  ClickHouseBaseResponseSchema,
+} from "../../schemas/schemas";
+
+interface Ctx {
+  organizationId: string;
+  invitationId?: string;
+}
+const base = (c: Ctx) => `/v1/organizations/${c.organizationId}/invitations`;
+
+export const invitationsHooks = createResourceHooks({
+  list: { path: base, schema: InvitationsResponseSchema },
+  item: { path: (c: Ctx) => `${base(c)}/${c.invitationId}`, schema: InvitationResponseSchema },
+  create: { method: "POST", path: base, schema: InvitationResponseSchema },
+  remove: { method: "DELETE", path: (c: Ctx) => `${base(c)}/${c.invitationId}`, schema: ClickHouseBaseResponseSchema },
+  invalidate: (c: Ctx) => [base(c), `${base(c)}/${c.invitationId}`],
+});
+

--- a/src/hooks/resources/organizationActivities.ts
+++ b/src/hooks/resources/organizationActivities.ts
@@ -1,0 +1,23 @@
+import { createResourceHooks } from "../createResourceHooks";
+import { ActivitiesResponseSchema, ActivityResponseSchema } from "../../schemas/schemas";
+
+interface Ctx {
+  organizationId: string;
+  activityId?: string;
+  fromDate?: string;
+  toDate?: string;
+}
+const listPath = (c: Ctx) => {
+  const q = new URLSearchParams();
+  if (c.fromDate) q.append("from_date", c.fromDate);
+  if (c.toDate) q.append("to_date", c.toDate);
+  const qs = q.toString();
+  return `/v1/organizations/${c.organizationId}/activities${qs ? `?${qs}` : ""}`;
+};
+
+export const organizationActivitiesHooks = createResourceHooks({
+  list: { path: listPath, schema: ActivitiesResponseSchema },
+  item: { path: (c: Ctx) => `/v1/organizations/${c.organizationId}/activities/${c.activityId}`, schema: ActivityResponseSchema },
+  invalidate: (c: Ctx) => [listPath({ organizationId: c.organizationId }), `/v1/organizations/${c.organizationId}/activities/${c.activityId}`],
+});
+

--- a/src/hooks/resources/organizations.ts
+++ b/src/hooks/resources/organizations.ts
@@ -1,0 +1,60 @@
+import { createResourceHooks } from "../createResourceHooks";
+import {
+  OrganizationsResponseSchema,
+  OrganizationResponseSchema,
+  UsageCostResponseSchema,
+  PrivateEndpointConfigResponseSchema,
+} from "../../schemas/schemas";
+
+interface Ctx {
+  organizationId?: string;
+}
+const base = `/v1/organizations`;
+
+export const organizationsHooks = createResourceHooks({
+  list: { path: () => base, schema: OrganizationsResponseSchema },
+  item: { path: (c: Ctx) => `${base}/${c.organizationId}`, schema: OrganizationResponseSchema },
+  update: { method: "PATCH", path: (c: Ctx) => `${base}/${c.organizationId}`, schema: OrganizationResponseSchema },
+  invalidate: (c: Ctx) => [base, `${base}/${c.organizationId}`],
+});
+
+// usage cost
+interface UsageCtx {
+  organizationId: string;
+  startDate?: string;
+  endDate?: string;
+}
+const usagePath = (c: UsageCtx) => {
+  const q = new URLSearchParams();
+  if (c.startDate) q.append("startDate", c.startDate);
+  if (c.endDate) q.append("endDate", c.endDate);
+  const qs = q.toString();
+  return `${base}/${c.organizationId}/usageCost${qs ? `?${qs}` : ""}`;
+};
+
+export const organizationUsageCostHooks = createResourceHooks({
+  list: { path: usagePath, schema: UsageCostResponseSchema },
+  item: { path: usagePath, schema: UsageCostResponseSchema },
+  invalidate: (c: UsageCtx) => [usagePath(c)],
+});
+
+// private endpoint config
+interface OpecCtx {
+  organizationId: string;
+  cloudProvider?: string;
+  region?: string;
+}
+const opecPath = (c: OpecCtx) => {
+  const q = new URLSearchParams();
+  if (c.cloudProvider) q.append("cloudProvider", c.cloudProvider);
+  if (c.region) q.append("region", c.region);
+  const qs = q.toString();
+  return `${base}/${c.organizationId}/privateEndpointConfig${qs ? `?${qs}` : ""}`;
+};
+
+export const organizationPrivateEndpointConfigHooks = createResourceHooks({
+  list: { path: opecPath, schema: PrivateEndpointConfigResponseSchema },
+  item: { path: opecPath, schema: PrivateEndpointConfigResponseSchema },
+  invalidate: (c: OpecCtx) => [opecPath(c)],
+});
+

--- a/src/hooks/resources/prometheus.ts
+++ b/src/hooks/resources/prometheus.ts
@@ -1,0 +1,23 @@
+import { createTextGetter } from "../createTextGetter";
+
+interface OrgCtx {
+  organizationId: string;
+  filteredMetrics?: boolean;
+}
+export const useOrgPrometheus = createTextGetter<OrgCtx>((c) =>
+  `/v1/organizations/${c.organizationId}/prometheus${
+    c.filteredMetrics !== undefined ? `?filtered_metrics=${c.filteredMetrics}` : ""
+  }`
+);
+
+interface SvcCtx {
+  organizationId: string;
+  serviceId: string;
+  filteredMetrics?: boolean;
+}
+export const useServicePrometheus = createTextGetter<SvcCtx>((c) =>
+  `/v1/organizations/${c.organizationId}/services/${c.serviceId}/prometheus${
+    c.filteredMetrics !== undefined ? `?filtered_metrics=${c.filteredMetrics}` : ""
+  }`
+);
+

--- a/src/hooks/resources/services.ts
+++ b/src/hooks/resources/services.ts
@@ -1,0 +1,54 @@
+import { createResourceHooks } from "../createResourceHooks";
+import { ServicesResponseSchema, ServiceResponseSchema } from "../../schemas/schemas";
+import { z } from "zod";
+
+interface Ctx {
+  organizationId: string;
+  serviceId?: string;
+}
+const base = (c: Ctx) => `/v1/organizations/${c.organizationId}/services`;
+
+export const servicesHooks = createResourceHooks({
+  list: { path: base, schema: ServicesResponseSchema },
+  item: { path: (c: Ctx) => `${base(c)}/${c.serviceId}`, schema: ServiceResponseSchema },
+  create: { method: "POST", path: base },
+  update: { method: "PATCH", path: (c: Ctx) => `${base(c)}/${c.serviceId}` },
+  remove: { method: "DELETE", path: (c: Ctx) => `${base(c)}/${c.serviceId}` },
+  actions: {
+    updateState: { method: "PATCH", path: (c: Ctx) => `${base(c)}/${c.serviceId}/state` },
+    updateReplicaScaling: { method: "PATCH", path: (c: Ctx) => `${base(c)}/${c.serviceId}/replicaScaling` },
+    updatePassword: { method: "PATCH", path: (c: Ctx) => `${base(c)}/${c.serviceId}/password` },
+    updateScaling: { method: "PATCH", path: (c: Ctx) => `${base(c)}/${c.serviceId}/scaling` },
+    createPrivateEndpoint: { method: "POST", path: (c: Ctx) => `${base(c)}/${c.serviceId}/privateEndpoint` },
+  },
+  invalidate: (c: Ctx) => [base(c), `${base(c)}/${c.serviceId}`],
+});
+
+// service query endpoint
+interface QECtx {
+  organizationId: string;
+  serviceId: string;
+}
+const qbase = (c: QECtx) => `/v1/organizations/${c.organizationId}/services/${c.serviceId}/serviceQueryEndpoint`;
+
+export const serviceQueryEndpointHooks = createResourceHooks({
+  list: { path: qbase, schema: z.any() },
+  item: { path: qbase, schema: z.any() },
+  create: { method: "POST", path: qbase },
+  remove: { method: "DELETE", path: qbase },
+  invalidate: (c: QECtx) => [qbase(c)],
+});
+
+// service private endpoint config
+interface SPECtx {
+  organizationId: string;
+  serviceId: string;
+}
+const spath = (c: SPECtx) => `/v1/organizations/${c.organizationId}/services/${c.serviceId}/privateEndpointConfig`;
+
+export const servicePrivateEndpointConfigHooks = createResourceHooks({
+  list: { path: spath, schema: z.any() },
+  item: { path: spath, schema: z.any() },
+  invalidate: (c: SPECtx) => [spath(c)],
+});
+

--- a/src/hooks/resources/userManagement.ts
+++ b/src/hooks/resources/userManagement.ts
@@ -1,0 +1,39 @@
+import { createResourceHooks } from "../createResourceHooks";
+import {
+  MembersResponseSchema,
+  MemberResponseSchema,
+  InvitationsResponseSchema,
+  InvitationResponseSchema,
+  ClickHouseBaseResponseSchema,
+} from "../../schemas/schemas";
+
+// Members
+interface MemberCtx {
+  organizationId: string;
+  userId?: string;
+}
+const mbase = (c: MemberCtx) => `/v1/organizations/${c.organizationId}/members`;
+
+export const membersHooks = createResourceHooks({
+  list: { path: mbase, schema: MembersResponseSchema },
+  item: { path: (c: MemberCtx) => `${mbase(c)}/${c.userId}`, schema: MemberResponseSchema },
+  update: { method: "PATCH", path: (c: MemberCtx) => `${mbase(c)}/${c.userId}`, schema: MemberResponseSchema },
+  remove: { method: "DELETE", path: (c: MemberCtx) => `${mbase(c)}/${c.userId}`, schema: ClickHouseBaseResponseSchema },
+  invalidate: (c: MemberCtx) => [mbase(c), `${mbase(c)}/${c.userId}`],
+});
+
+// Organization Invitations (same as invitations)
+interface InviteCtx {
+  organizationId: string;
+  invitationId?: string;
+}
+const ibase = (c: InviteCtx) => `/v1/organizations/${c.organizationId}/invitations`;
+
+export const orgInvitationsHooks = createResourceHooks({
+  list: { path: ibase, schema: InvitationsResponseSchema },
+  item: { path: (c: InviteCtx) => `${ibase(c)}/${c.invitationId}`, schema: InvitationResponseSchema },
+  create: { method: "POST", path: ibase, schema: InvitationResponseSchema },
+  remove: { method: "DELETE", path: (c: InviteCtx) => `${ibase(c)}/${c.invitationId}`, schema: ClickHouseBaseResponseSchema },
+  invalidate: (c: InviteCtx) => [ibase(c), `${ibase(c)}/${c.invitationId}`],
+});
+

--- a/src/hooks/tests/useBackups.test.tsx
+++ b/src/hooks/tests/useBackups.test.tsx
@@ -167,7 +167,12 @@ describe("useDeleteServiceBackup", () => {
   });
 
   function HookTest({ onResult }: { onResult: (r: ReturnType<typeof useDeleteServiceBackup>) => void }) {
-    const result = useDeleteServiceBackup(organizationId, serviceId, config);
+    const result = useDeleteServiceBackup(
+      organizationId,
+      serviceId,
+      backupId,
+      config
+    );
     React.useEffect(() => {
       onResult(result);
     }, [result, onResult]);
@@ -178,7 +183,7 @@ describe("useDeleteServiceBackup", () => {
     let hookResult: ReturnType<typeof useDeleteServiceBackup> | undefined;
     render(<HookTest onResult={(r) => (hookResult = r)} />);
     await waitFor(() => expect(hookResult).toBeDefined());
-    await hookResult!.deleteBackup(backupId);
+    await hookResult!.deleteBackup();
     expect(global.fetch).toHaveBeenCalledWith(
       `${config.baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/backups/${backupId}`,
       expect.objectContaining({ method: "DELETE" })
@@ -196,6 +201,6 @@ describe("useDeleteServiceBackup", () => {
     let hookResult: ReturnType<typeof useDeleteServiceBackup> | undefined;
     render(<HookTest onResult={(r) => (hookResult = r)} />);
     await waitFor(() => expect(hookResult).toBeDefined());
-    await expect(hookResult!.deleteBackup(backupId)).rejects.toThrow("Not found");
+    await expect(hookResult!.deleteBackup()).rejects.toThrow("Not found");
   });
 });

--- a/src/hooks/useApiKeys.ts
+++ b/src/hooks/useApiKeys.ts
@@ -1,18 +1,7 @@
-import { useSWRConfig } from "swr";
 import type { ClickHouseConfig } from "../api/fetcher";
-import { useClickHouseSWR } from "./useClickHouseSWR";
-import {
-  ApiKeysResponseSchema,
-  ApiKeyResponseSchema,
-  ApiKeyCreateResponseSchema,
-  ClickHouseBaseResponseSchema,
-  type ApiKeysResponse,
-  type ApiKeyResponse,
-  type ApiKey,
-  type ClickHouseBaseResponse,
-} from "../schemas/schemas";
+import { apiKeyHooks } from "./resources/apiKeys";
 
-type ApiKeyCreateRequest = {
+export type ApiKeyCreateRequest = {
   name: string;
   roles: ("admin" | "developer" | "query_endpoints")[];
   expireAt?: string | null;
@@ -20,156 +9,40 @@ type ApiKeyCreateRequest = {
   ipAccessList?: { source: string; description: string }[];
 };
 
-type ApiKeyUpdateRequest = Partial<ApiKeyCreateRequest>;
+export type ApiKeyUpdateRequest = Partial<ApiKeyCreateRequest>;
 
-export function useApiKeys(organizationId: string, config: ClickHouseConfig) {
-  return useClickHouseSWR<ApiKeysResponse>(
-    `/v1/organizations/${organizationId}/keys`,
-    config,
-    ApiKeysResponseSchema
-  );
-}
+export const useApiKeys = (organizationId: string, config: ClickHouseConfig) =>
+  apiKeyHooks.useList({ organizationId }, config);
 
-export function useCreateApiKey(
-  organizationId: string,
-  config: ClickHouseConfig
-) {
-  const { mutate } = useClickHouseSWR<ApiKeysResponse>(
-    `/v1/organizations/${organizationId}/keys`,
-    config,
-    ApiKeysResponseSchema
-  );
-
-  const createApiKey = async (keyData: ApiKeyCreateRequest) => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/keys`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(keyData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-
-    const validatedResponse = ApiKeyCreateResponseSchema.parse(responseData);
-
-    await mutate();
-
-    return validatedResponse.result;
-  };
-
-  return { createApiKey };
-}
-
-export function useApiKey(
+export const useApiKey = (
   organizationId: string,
   keyId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR<ApiKeyResponse>(
-    `/v1/organizations/${organizationId}/keys/${keyId}`,
-    config,
-    ApiKeyResponseSchema
-  );
-}
+) => apiKeyHooks.useOne({ organizationId, keyId }, config);
 
-export function useUpdateApiKey(
+export const useCreateApiKey = (
+  organizationId: string,
+  config: ClickHouseConfig
+) => {
+  const create = apiKeyHooks.useCreate({ organizationId }, config);
+  return { createApiKey: (body: ApiKeyCreateRequest) => create(body) };
+};
+
+export const useUpdateApiKey = (
   organizationId: string,
   keyId: string,
   config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
+) => {
+  const update = apiKeyHooks.useUpdate({ organizationId, keyId }, config);
+  return { updateApiKey: (body: ApiKeyUpdateRequest) => update(body) };
+};
 
-  const updateApiKey = async (
-    updateData: ApiKeyUpdateRequest
-  ): Promise<ApiKey> => {
-    const {
-      keyId: configKeyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${configKeyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/keys/${keyId}`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(updateData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-
-    const validatedResponse = ApiKeyResponseSchema.parse(responseData);
-
-    await Promise.all([
-      globalMutate(
-        `/v1/organizations/${organizationId}/keys:${config.baseUrl}:${config.keyId}`
-      ),
-      globalMutate(
-        `/v1/organizations/${organizationId}/keys/${keyId}:${config.baseUrl}:${config.keyId}`
-      ),
-    ]);
-
-    return validatedResponse.result;
-  };
-
-  return { updateApiKey };
-}
-
-export function useDeleteApiKey(
+export const useDeleteApiKey = (
   organizationId: string,
   keyId: string,
   config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
+) => {
+  const del = apiKeyHooks.useDelete({ organizationId, keyId }, config);
+  return { deleteApiKey: () => del() };
+};
 
-  const deleteApiKey = async (): Promise<ClickHouseBaseResponse> => {
-    const {
-      keyId: configKeyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${configKeyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/keys/${keyId}`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-
-    const validatedResponse = ClickHouseBaseResponseSchema.parse(responseData);
-
-    await Promise.all([
-      globalMutate(
-        `/v1/organizations/${organizationId}/keys:${config.baseUrl}:${config.keyId}`
-      ),
-      globalMutate(
-        `/v1/organizations/${organizationId}/keys/${keyId}:${config.baseUrl}:${config.keyId}`
-      ),
-    ]);
-
-    return validatedResponse;
-  };
-
-  return { deleteApiKey };
-}

--- a/src/hooks/useBackups.ts
+++ b/src/hooks/useBackups.ts
@@ -1,119 +1,52 @@
-import { useSWRConfig } from "swr";
 import type { ClickHouseConfig } from "../api/fetcher";
-import { useClickHouseSWR } from "./useClickHouseSWR";
 import {
-  BackupsResponseSchema,
-  BackupResponseSchema,
-  BackupConfigurationResponseSchema,
-  type BackupsResponse,
-  type BackupResponse,
-  type BackupConfigurationResponse,
-  type BackupConfiguration,
-} from "../schemas/schemas";
+  serviceBackupsHooks,
+  serviceBackupConfigurationHooks,
+} from "./resources/backups";
 
-export function useServiceBackups(
+export const useServiceBackups = (
   organizationId: string,
   serviceId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR<BackupsResponse>(
-    `/v1/organizations/${organizationId}/services/${serviceId}/backups`,
-    config,
-    BackupsResponseSchema
-  );
-}
+) => serviceBackupsHooks.useList({ organizationId, serviceId }, config);
 
-export function useServiceBackup(
+export const useServiceBackup = (
   organizationId: string,
   serviceId: string,
   backupId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR<BackupResponse>(
-    `/v1/organizations/${organizationId}/services/${serviceId}/backups/${backupId}`,
-    config,
-    BackupResponseSchema
+) =>
+  serviceBackupsHooks.useOne({ organizationId, serviceId, backupId }, config);
+
+export const useServiceBackupConfiguration = (
+  organizationId: string,
+  serviceId: string,
+  config: ClickHouseConfig
+) =>
+  serviceBackupConfigurationHooks.useOne({ organizationId, serviceId }, config);
+
+export const useUpdateServiceBackupConfiguration = (
+  organizationId: string,
+  serviceId: string,
+  config: ClickHouseConfig
+) => {
+  const update = serviceBackupConfigurationHooks.useUpdate(
+    { organizationId, serviceId },
+    config
   );
-}
+  return { updateBackupConfiguration: (body: unknown) => update(body) };
+};
 
-export function useServiceBackupConfiguration(
+export const useDeleteServiceBackup = (
   organizationId: string,
   serviceId: string,
+  backupId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR<BackupConfigurationResponse>(
-    `/v1/organizations/${organizationId}/services/${serviceId}/backupConfiguration`,
-    config,
-    BackupConfigurationResponseSchema
+) => {
+  const del = serviceBackupsHooks.useDelete(
+    { organizationId, serviceId, backupId },
+    config
   );
-}
+  return { deleteBackup: () => del() };
+};
 
-export function useUpdateServiceBackupConfiguration(
-  organizationId: string,
-  serviceId: string,
-  config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
-  const updateBackupConfiguration = async (
-    configData: Partial<BackupConfiguration>
-  ): Promise<BackupConfiguration> => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/backupConfiguration`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(configData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-    const validated = BackupConfigurationResponseSchema.parse(responseData);
-
-    await globalMutate(
-      `/v1/organizations/${organizationId}/services/${serviceId}/backupConfiguration:${config.baseUrl}:${config.keyId}`
-    );
-
-    return validated.result;
-  };
-
-  return { updateBackupConfiguration };
-}
-
-export function useDeleteServiceBackup(
-  organizationId: string,
-  serviceId: string,
-  config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
-
-  const deleteBackup = async (backupId: string) => {
-    const { keyId, keySecret, baseUrl = "https://api.clickhouse.cloud" } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/backups/${backupId}`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    await response.json().catch(() => undefined);
-    await globalMutate(
-      `/v1/organizations/${organizationId}/services/${serviceId}/backups:${config.baseUrl}:${config.keyId}`
-    );
-  };
-
-  return { deleteBackup };
-}

--- a/src/hooks/useClickpipes.ts
+++ b/src/hooks/useClickpipes.ts
@@ -1,232 +1,75 @@
-import { useSWRConfig } from "swr";
 import type { ClickHouseConfig } from "../api/fetcher";
-import {
-  ClickPipeResponseSchema,
-  ClickPipesResponseSchema,
-  ClickHouseBaseResponseSchema,
-  type ClickPipe,
-  type ClickPipeResponse,
-  type ClickPipesResponse,
-} from "../schemas/schemas";
-import { useClickHouseSWR } from "./useClickHouseSWR";
+import { clickpipeHooks } from "./resources/clickpipes";
 
-export function useClickpipes(
+export const useClickpipes = (
   organizationId: string,
   serviceId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR<ClickPipesResponse>(
-    `/v1/organizations/${organizationId}/services/${serviceId}/clickpipes`,
-    config,
-    ClickPipesResponseSchema
+) => clickpipeHooks.useList({ organizationId, serviceId }, config);
+
+export const useClickpipe = (
+  organizationId: string,
+  serviceId: string,
+  clickPipeId: string,
+  config: ClickHouseConfig
+) =>
+  clickpipeHooks.useOne({ organizationId, serviceId, clickPipeId }, config);
+
+export const useCreateClickpipe = (
+  organizationId: string,
+  serviceId: string,
+  config: ClickHouseConfig
+) => {
+  const create = clickpipeHooks.useCreate({ organizationId, serviceId }, config);
+  return { createClickpipe: (body: unknown) => create(body) };
+};
+
+export const useUpdateClickpipe = (
+  organizationId: string,
+  serviceId: string,
+  clickPipeId: string,
+  config: ClickHouseConfig
+) => {
+  const update = clickpipeHooks.useUpdate(
+    { organizationId, serviceId, clickPipeId },
+    config
   );
-}
+  return { updateClickpipe: (body: unknown) => update(body) };
+};
 
-export function useClickpipe(
+export const useDeleteClickpipe = (
   organizationId: string,
   serviceId: string,
   clickPipeId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR<ClickPipeResponse>(
-    `/v1/organizations/${organizationId}/services/${serviceId}/clickpipes/${clickPipeId}`,
-    config,
-    ClickPipeResponseSchema
+) => {
+  const del = clickpipeHooks.useDelete({ organizationId, serviceId, clickPipeId }, config);
+  return { deleteClickpipe: () => del() };
+};
+
+export const useClickpipeScaling = (
+  organizationId: string,
+  serviceId: string,
+  clickPipeId: string,
+  config: ClickHouseConfig
+) => {
+  const { updateScaling } = clickpipeHooks.useActions(
+    { organizationId, serviceId, clickPipeId },
+    config
   );
-}
+  return { updateClickpipeScaling: (body: unknown) => updateScaling(body) };
+};
 
-export function useCreateClickpipe(
-  organizationId: string,
-  serviceId: string,
-  config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
-
-  const createClickpipe = async (clickpipeData: unknown): Promise<ClickPipe> => {
-    const { keyId, keySecret, baseUrl = "https://api.clickhouse.cloud" } =
-      config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/clickpipes`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(clickpipeData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-    const validated = ClickPipeResponseSchema.parse(responseData);
-    await globalMutate(
-      `/v1/organizations/${organizationId}/services/${serviceId}/clickpipes:${config.baseUrl}:${config.keyId}`
-    );
-    return validated.result;
-  };
-
-  return { createClickpipe };
-}
-
-export function useUpdateClickpipe(
+export const useClickpipeState = (
   organizationId: string,
   serviceId: string,
   clickPipeId: string,
   config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
-
-  const updateClickpipe = async (updateData: unknown): Promise<ClickPipe> => {
-    const { keyId, keySecret, baseUrl = "https://api.clickhouse.cloud" } =
-      config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/clickpipes/${clickPipeId}`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(updateData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-    const validated = ClickPipeResponseSchema.parse(responseData);
-    await Promise.all([
-      globalMutate(
-        `/v1/organizations/${organizationId}/services/${serviceId}/clickpipes:${config.baseUrl}:${config.keyId}`
-      ),
-      globalMutate(
-        `/v1/organizations/${organizationId}/services/${serviceId}/clickpipes/${clickPipeId}:${config.baseUrl}:${config.keyId}`
-      ),
-    ]);
-    return validated.result;
-  };
-
-  return { updateClickpipe };
-}
-
-export function useDeleteClickpipe(
-  organizationId: string,
-  serviceId: string,
-  clickPipeId: string,
-  config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
-
-  const deleteClickpipe = async () => {
-    const { keyId, keySecret, baseUrl = "https://api.clickhouse.cloud" } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/clickpipes/${clickPipeId}`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-    const validated = ClickHouseBaseResponseSchema.parse(responseData);
-    await Promise.all([
-      globalMutate(
-        `/v1/organizations/${organizationId}/services/${serviceId}/clickpipes:${config.baseUrl}:${config.keyId}`
-      ),
-      globalMutate(
-        `/v1/organizations/${organizationId}/services/${serviceId}/clickpipes/${clickPipeId}:${config.baseUrl}:${config.keyId}`
-      ),
-    ]);
-    return validated;
-  };
-
-  return { deleteClickpipe };
-}
-
-export function useClickpipeScaling(
-  organizationId: string,
-  serviceId: string,
-  clickPipeId: string,
-  config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
-
-  const updateClickpipeScaling = async (
-    scalingData: unknown
-  ): Promise<ClickPipe> => {
-    const { keyId, keySecret, baseUrl = "https://api.clickhouse.cloud" } =
-      config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/clickpipes/${clickPipeId}/scaling`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(scalingData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-    const validated = ClickPipeResponseSchema.parse(responseData);
-    await Promise.all([
-      globalMutate(
-        `/v1/organizations/${organizationId}/services/${serviceId}/clickpipes:${config.baseUrl}:${config.keyId}`
-      ),
-      globalMutate(
-        `/v1/organizations/${organizationId}/services/${serviceId}/clickpipes/${clickPipeId}:${config.baseUrl}:${config.keyId}`
-      ),
-    ]);
-    return validated.result;
-  };
-
-  return { updateClickpipeScaling };
-}
-
-export function useClickpipeState(
-  organizationId: string,
-  serviceId: string,
-  clickPipeId: string,
-  config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
-
-  const updateClickpipeState = async (
-    stateData: { command: "start" | "stop" | "resync" }
-  ): Promise<ClickPipe> => {
-    const { keyId, keySecret, baseUrl = "https://api.clickhouse.cloud" } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/clickpipes/${clickPipeId}/state`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(stateData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-    const validated = ClickPipeResponseSchema.parse(responseData);
-    await Promise.all([
-      globalMutate(
-        `/v1/organizations/${organizationId}/services/${serviceId}/clickpipes:${config.baseUrl}:${config.keyId}`
-      ),
-      globalMutate(
-        `/v1/organizations/${organizationId}/services/${serviceId}/clickpipes/${clickPipeId}:${config.baseUrl}:${config.keyId}`
-      ),
-    ]);
-    return validated.result;
-  };
-
-  return { updateClickpipeState };
-}
+) => {
+  const { updateState } = clickpipeHooks.useActions(
+    { organizationId, serviceId, clickPipeId },
+    config
+  );
+  return { updateClickpipeState: (body: unknown) => updateState(body) };
+};
 

--- a/src/hooks/useClickpipesReversePrivateEndpoints.ts
+++ b/src/hooks/useClickpipesReversePrivateEndpoints.ts
@@ -1,95 +1,42 @@
 import type { ClickHouseConfig } from "../api/fetcher";
-import { useClickHouseSWR } from "./useClickHouseSWR";
-import {
-  ReversePrivateEndpointsResponseSchema,
-  ReversePrivateEndpointResponseSchema,
-  ClickHouseBaseResponseSchema,
-  type ReversePrivateEndpoint,
-  type ReversePrivateEndpointsResponse,
-  type ReversePrivateEndpointResponse,
-  type CreateReversePrivateEndpoint,
-} from "../schemas/schemas";
+import { clickpipesRpeHooks } from "./resources/clickpipesReversePrivateEndpoints";
 
-export function useClickpipesReversePrivateEndpoints(
+export const useClickpipesReversePrivateEndpoints = (
   organizationId: string,
   serviceId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR<ReversePrivateEndpointsResponse>(
-    `/v1/organizations/${organizationId}/services/${serviceId}/clickpipesReversePrivateEndpoints`,
-    config,
-    ReversePrivateEndpointsResponseSchema
+) => clickpipesRpeHooks.useList({ organizationId, serviceId }, config);
+
+export const useClickpipesReversePrivateEndpoint = (
+  organizationId: string,
+  serviceId: string,
+  endpointId: string,
+  config: ClickHouseConfig
+) =>
+  clickpipesRpeHooks.useOne(
+    { organizationId, serviceId, endpointId },
+    config
   );
-}
 
-export function useCreateClickpipesReversePrivateEndpoint(
+export const useCreateClickpipesReversePrivateEndpoint = (
   organizationId: string,
   serviceId: string,
   config: ClickHouseConfig
-) {
-  const createReversePrivateEndpoint = async (
-    endpointData: CreateReversePrivateEndpoint
-  ): Promise<ReversePrivateEndpoint> => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/clickpipesReversePrivateEndpoints`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(endpointData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-    const validated = ReversePrivateEndpointResponseSchema.parse(responseData);
-    return validated.result;
-  };
-  return { createReversePrivateEndpoint };
-}
+) => {
+  const create = clickpipesRpeHooks.useCreate({ organizationId, serviceId }, config);
+  return { createReversePrivateEndpoint: (body: unknown) => create(body) };
+};
 
-export function useClickpipesReversePrivateEndpoint(
+export const useDeleteClickpipesReversePrivateEndpoint = (
   organizationId: string,
   serviceId: string,
-  reversePrivateEndpointId: string,
+  endpointId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR<ReversePrivateEndpointResponse>(
-    `/v1/organizations/${organizationId}/services/${serviceId}/clickpipesReversePrivateEndpoints/${reversePrivateEndpointId}`,
-    config,
-    ReversePrivateEndpointResponseSchema
+) => {
+  const del = clickpipesRpeHooks.useDelete(
+    { organizationId, serviceId, endpointId },
+    config
   );
-}
+  return { deleteReversePrivateEndpoint: () => del() };
+};
 
-export function useDeleteClickpipesReversePrivateEndpoint(
-  organizationId: string,
-  serviceId: string,
-  reversePrivateEndpointId: string,
-  config: ClickHouseConfig
-) {
-  const deleteReversePrivateEndpoint = async () => {
-    const { keyId, keySecret, baseUrl = "https://api.clickhouse.cloud" } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/clickpipesReversePrivateEndpoints/${reversePrivateEndpointId}`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-    return ClickHouseBaseResponseSchema.parse(responseData);
-  };
-  return { deleteReversePrivateEndpoint };
-}

--- a/src/hooks/useOrganizationActivities.ts
+++ b/src/hooks/useOrganizationActivities.ts
@@ -1,39 +1,16 @@
 import type { ClickHouseConfig } from "../api/fetcher";
-import { useClickHouseSWR } from "./useClickHouseSWR";
-import {
-  ActivitiesResponseSchema,
-  ActivityResponseSchema,
-  type ActivitiesResponse,
-  type ActivityResponse,
-} from "../schemas/schemas";
+import { organizationActivitiesHooks } from "./resources/organizationActivities";
 
-export function useOrganizationActivities(
+export const useOrganizationActivities = (
   organizationId: string,
   config: ClickHouseConfig,
   params?: { fromDate?: string; toDate?: string }
-) {
-  const queryParams = new URLSearchParams();
-  if (params?.fromDate) queryParams.append("from_date", params.fromDate);
-  if (params?.toDate) queryParams.append("to_date", params.toDate);
-  const queryString = queryParams.toString();
-  const url = `/v1/organizations/${organizationId}/activities${
-    queryString ? `?${queryString}` : ""
-  }`;
-  return useClickHouseSWR<ActivitiesResponse>(
-    url,
-    config,
-    ActivitiesResponseSchema
-  );
-}
+) => organizationActivitiesHooks.useList({ organizationId, ...params }, config);
 
-export function useOrganizationActivity(
+export const useOrganizationActivity = (
   organizationId: string,
   activityId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR<ActivityResponse>(
-    `/v1/organizations/${organizationId}/activities/${activityId}`,
-    config,
-    ActivityResponseSchema
-  );
-}
+) =>
+  organizationActivitiesHooks.useOne({ organizationId, activityId }, config);
+

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -1,121 +1,44 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { useSWRConfig } from "swr";
 import type { ClickHouseConfig } from "../api/fetcher";
 import {
-  OrganizationsResponseSchema,
-  OrganizationResponseSchema,
-  UsageCostResponseSchema,
-  PrivateEndpointConfigResponseSchema,
-  type OrganizationsResponse,
-  type OrganizationResponse,
-  type UsageCostResponse,
-  type PrivateEndpointConfigResponse,
-  type Organization,
-} from "../schemas/schemas";
-import { useClickHouseSWR } from "./useClickHouseSWR";
+  organizationsHooks,
+  organizationUsageCostHooks,
+  organizationPrivateEndpointConfigHooks,
+} from "./resources/organizations";
+import type { Organization } from "../schemas/schemas";
 
-export function useOrganizations(config: ClickHouseConfig) {
-  return useClickHouseSWR<OrganizationsResponse>(
-    "/v1/organizations",
-    config,
-    OrganizationsResponseSchema
-  );
-}
+export const useOrganizations = (config: ClickHouseConfig) =>
+  organizationsHooks.useList({}, config);
 
-export function useOrganization(
+export const useOrganization = (
   organizationId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR<OrganizationResponse>(
-    `/v1/organizations/${organizationId}`,
-    config,
-    OrganizationResponseSchema
-  );
-}
+) => organizationsHooks.useOne({ organizationId }, config);
 
-export function useUpdateOrganization(
+export const useUpdateOrganization = (
   organizationId: string,
   config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
+) => {
+  const update = organizationsHooks.useUpdate({ organizationId }, config);
+  return { updateOrganization: (body: Partial<Organization>) => update(body) };
+};
 
-  const updateOrganization = async (
-    updateData: Partial<Organization>
-  ): Promise<Organization> => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(updateData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-
-    // Validate the response
-    const validatedResponse = OrganizationResponseSchema.parse(responseData);
-
-    // Invalidate related cache entries
-    await Promise.all([
-      globalMutate(
-        `/v1/organizations:${config.baseUrl}:${config.keyId}`
-      ),
-      globalMutate(
-        `/v1/organizations/${organizationId}:${config.baseUrl}:${config.keyId}`
-      ),
-    ]);
-
-    return validatedResponse.result;
-  };
-
-  return { updateOrganization };
-}
-
-export function useOrganizationUsageCost(
+export const useOrganizationUsageCost = (
   organizationId: string,
   config: ClickHouseConfig,
   params?: { startDate?: string; endDate?: string }
-) {
-  const queryParams = new URLSearchParams();
-  if (params?.startDate) queryParams.append("startDate", params.startDate);
-  if (params?.endDate) queryParams.append("endDate", params.endDate);
-  const queryString = queryParams.toString();
-  const url = `/v1/organizations/${organizationId}/usageCost${
-    queryString ? `?${queryString}` : ""
-  }`;
-  return useClickHouseSWR<UsageCostResponse>(
-    url,
-    config,
-    UsageCostResponseSchema
+) =>
+  organizationUsageCostHooks.useOne(
+    { organizationId, ...params },
+    config
   );
-}
 
-export function useOrganizationPrivateEndpointConfig(
+export const useOrganizationPrivateEndpointConfig = (
   organizationId: string,
   config: ClickHouseConfig,
   params?: { cloudProvider?: string; region?: string }
-) {
-  const queryParams = new URLSearchParams();
-  if (params?.cloudProvider)
-    queryParams.append("cloudProvider", params.cloudProvider);
-  if (params?.region) queryParams.append("region", params.region);
-  const queryString = queryParams.toString();
-  const url = `/v1/organizations/${organizationId}/privateEndpointConfig${
-    queryString ? `?${queryString}` : ""
-  }`;
-  return useClickHouseSWR<PrivateEndpointConfigResponse>(
-    url,
-    config,
-    PrivateEndpointConfigResponseSchema
+) =>
+  organizationPrivateEndpointConfigHooks.useOne(
+    { organizationId, ...params },
+    config
   );
-}
+

--- a/src/hooks/usePrometheusMetrics.ts
+++ b/src/hooks/usePrometheusMetrics.ts
@@ -1,43 +1,23 @@
-import useSWR from "swr";
-import { fetcher } from "../api/fetcher";
 import type { ClickHouseConfig } from "../api/fetcher";
+import {
+  useOrgPrometheus,
+  useServicePrometheus,
+} from "./resources/prometheus";
 
-// Fetch organization-level Prometheus metrics
-export function useOrganizationPrometheusMetrics(
+export const useOrganizationPrometheusMetrics = (
   organizationId: string,
   config: ClickHouseConfig,
   filteredMetrics?: boolean
-) {
-  const query =
-    filteredMetrics !== undefined
-      ? `?filtered_metrics=${filteredMetrics}`
-      : "";
-  const { data, error, isLoading } = useSWR(
-    [`/v1/organizations/${organizationId}/prometheus${query}`, config],
-    ([url, cfg]: [string, ClickHouseConfig]) =>
-      fetcher<string>(url, cfg, undefined, "text")
-  );
-  return { data, error, isLoading };
-}
+) => useOrgPrometheus({ organizationId, filteredMetrics }, config);
 
-// Fetch service-level Prometheus metrics
-export function useServicePrometheusMetrics(
+export const useServicePrometheusMetrics = (
   organizationId: string,
   serviceId: string,
   config: ClickHouseConfig,
   filteredMetrics?: boolean
-) {
-  const query =
-    filteredMetrics !== undefined
-      ? `?filtered_metrics=${filteredMetrics}`
-      : "";
-  const { data, error, isLoading } = useSWR(
-    [
-      `/v1/organizations/${organizationId}/services/${serviceId}/prometheus${query}`,
-      config,
-    ],
-    ([url, cfg]: [string, ClickHouseConfig]) =>
-      fetcher<string>(url, cfg, undefined, "text")
+) =>
+  useServicePrometheus(
+    { organizationId, serviceId, filteredMetrics },
+    config
   );
-  return { data, error, isLoading };
-}
+

--- a/src/hooks/useServices.ts
+++ b/src/hooks/useServices.ts
@@ -1,375 +1,129 @@
-import useSWR from "swr";
-import { fetcher } from "../api/fetcher";
-import { useClickHouseSWR } from "./useClickHouseSWR";
-import {
-  type ServicesResponse,
-  ServicesResponseSchema,
-  type ServiceResponse,
-  ServiceResponseSchema,
-} from "../schemas/schemas";
 import type { ClickHouseConfig } from "../api/fetcher";
+import {
+  servicesHooks,
+  serviceQueryEndpointHooks,
+  servicePrivateEndpointConfigHooks,
+} from "./resources/services";
+import { useServicePrometheus as useServiceProm } from "./resources/prometheus";
 
-export function useServices(organizationId: string, config: ClickHouseConfig) {
-  return useClickHouseSWR<ServicesResponse>(
-    `/v1/organizations/${organizationId}/services`,
-    config,
-    ServicesResponseSchema
+export const useServices = (
+  organizationId: string,
+  config: ClickHouseConfig
+) => servicesHooks.useList({ organizationId }, config);
+
+export const useService = (
+  organizationId: string,
+  serviceId: string,
+  config: ClickHouseConfig
+) => servicesHooks.useOne({ organizationId, serviceId }, config);
+
+export const useCreateService = (
+  organizationId: string,
+  config: ClickHouseConfig
+) => {
+  const create = servicesHooks.useCreate({ organizationId }, config);
+  return { createService: (body: unknown) => create(body) };
+};
+
+export const useUpdateService = (
+  organizationId: string,
+  serviceId: string,
+  config: ClickHouseConfig
+) => {
+  const update = servicesHooks.useUpdate({ organizationId, serviceId }, config);
+  return { updateService: (body: unknown) => update(body) };
+};
+
+export const useDeleteService = (
+  organizationId: string,
+  serviceId: string,
+  config: ClickHouseConfig
+) => {
+  const del = servicesHooks.useDelete({ organizationId, serviceId }, config);
+  return { deleteService: () => del() };
+};
+
+export const useServiceState = (
+  organizationId: string,
+  serviceId: string,
+  config: ClickHouseConfig
+) => {
+  const { updateState } = servicesHooks.useActions({ organizationId, serviceId }, config);
+  return { updateServiceState: (body: unknown) => updateState(body) };
+};
+
+export const useServiceReplicaScaling = (
+  organizationId: string,
+  serviceId: string,
+  config: ClickHouseConfig
+) => {
+  const { updateReplicaScaling } = servicesHooks.useActions(
+    { organizationId, serviceId },
+    config
   );
-}
+  return { updateServiceScaling: (body: unknown) => updateReplicaScaling(body) };
+};
 
-export function useService(
+export const useServicePassword = (
   organizationId: string,
   serviceId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR<ServiceResponse>(
-    `/v1/organizations/${organizationId}/services/${serviceId}`,
-    config,
-    ServiceResponseSchema
+) => {
+  const { updatePassword } = servicesHooks.useActions({ organizationId, serviceId }, config);
+  return { updateServicePassword: (body: { newPassword: string }) => updatePassword(body) };
+};
+
+export const useServicePrivateEndpointConfig = (
+  organizationId: string,
+  serviceId: string,
+  config: ClickHouseConfig
+) =>
+  servicePrivateEndpointConfigHooks.useOne({ organizationId, serviceId }, config);
+
+export const useServiceQueryEndpoint = (
+  organizationId: string,
+  serviceId: string,
+  config: ClickHouseConfig
+) => {
+  const query = serviceQueryEndpointHooks.useOne({ organizationId, serviceId }, config);
+  const create = serviceQueryEndpointHooks.useCreate(
+    { organizationId, serviceId },
+    config
   );
-}
-
-export function useCreateService(
-  organizationId: string,
-  config: ClickHouseConfig
-) {
-  const createService = async (serviceData: unknown) => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(serviceData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    return response.json();
-  };
-
-  return { createService };
-}
-
-export function useUpdateService(
-  organizationId: string,
-  serviceId: string,
-  config: ClickHouseConfig
-) {
-  const updateService = async (updateData: unknown) => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(updateData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    return response.json();
-  };
-
-  return { updateService };
-}
-
-export function useDeleteService(
-  organizationId: string,
-  serviceId: string,
-  config: ClickHouseConfig
-) {
-  const deleteService = async () => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    return response.json();
-  };
-
-  return { deleteService };
-}
-
-export function useServiceState(
-  organizationId: string,
-  serviceId: string,
-  config: ClickHouseConfig
-) {
-  const updateServiceState = async (stateData: {
-    command: "start" | "stop";
-  }) => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/state`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(stateData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    return response.json();
-  };
-
-  return { updateServiceState };
-}
-
-export function useServiceReplicaScaling(
-  organizationId: string,
-  serviceId: string,
-  config: ClickHouseConfig
-) {
-  const updateServiceScaling = async (scalingData: unknown) => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/replicaScaling`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(scalingData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    return response.json();
-  };
-
-  return { updateServiceScaling };
-}
-
-export function useServicePassword(
-  organizationId: string,
-  serviceId: string,
-  config: ClickHouseConfig
-) {
-  const updateServicePassword = async (passwordData: {
-    newPassword: string;
-  }) => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/password`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(passwordData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    return response.json();
-  };
-
-  return { updateServicePassword };
-}
-
-export function useServicePrivateEndpointConfig(
-  organizationId: string,
-  serviceId: string,
-  config: ClickHouseConfig
-) {
-  const { data, error, isLoading } = useSWR<any>(
-    [
-      `/v1/organizations/${organizationId}/services/${serviceId}/privateEndpointConfig`,
-      config,
-    ],
-    ([url, cfg]: [string, ClickHouseConfig]) => fetcher<any>(url, cfg)
-  );
-  return { data: data?.result, error, isLoading, response: data };
-}
-
-export function useServiceQueryEndpoint(
-  organizationId: string,
-  serviceId: string,
-  config: ClickHouseConfig
-) {
-  const { data, error, isLoading } = useSWR<any>(
-    [
-      `/v1/organizations/${organizationId}/services/${serviceId}/serviceQueryEndpoint`,
-      config,
-    ],
-    ([url, cfg]: [string, ClickHouseConfig]) => fetcher<any>(url, cfg)
-  );
-
-  const createQueryEndpoint = async (endpointData: unknown) => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/serviceQueryEndpoint`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(endpointData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    return response.json();
-  };
-
-  const deleteQueryEndpoint = async () => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/serviceQueryEndpoint`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    return response.json();
-  };
-
+  const del = serviceQueryEndpointHooks.useDelete({ organizationId, serviceId }, config);
   return {
-    data: data?.result,
-    error,
-    isLoading,
-    response: data,
-    createQueryEndpoint,
-    deleteQueryEndpoint,
+    ...query,
+    createQueryEndpoint: (body: unknown) => create(body),
+    deleteQueryEndpoint: () => del(),
   };
-}
+};
 
-export function useServicePrometheus(
+export const useServicePrometheus = (
   organizationId: string,
   serviceId: string,
   config: ClickHouseConfig,
   params?: { filteredMetrics?: boolean }
-) {
-  const query = params?.filteredMetrics ? "?filtered_metrics=true" : "";
-  const { data, error, isLoading } = useSWR(
-    [`/v1/organizations/${organizationId}/services/${serviceId}/prometheus${query}`, config],
-    async ([url, cfg]: [string, ClickHouseConfig]) => {
-      const { keyId, keySecret, baseUrl = "https://api.clickhouse.cloud" } = cfg;
-      const auth = btoa(`${keyId}:${keySecret}`);
-      const res = await fetch(`${baseUrl}${url}`, {
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-      return res.text();
-    }
-  );
-  return { data, error, isLoading };
-}
-export function useCreateServicePrivateEndpoint(
-  organizationId: string,
-  serviceId: string,
-  config: ClickHouseConfig
-) {
-  const createPrivateEndpoint = async (endpointData: unknown) => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/privateEndpoint`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(endpointData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    return response.json();
-  };
-  return { createPrivateEndpoint };
-}
+) =>
+  useServiceProm({ organizationId, serviceId, filteredMetrics: params?.filteredMetrics }, config);
 
-export function useServiceScaling(
+export const useCreateServicePrivateEndpoint = (
   organizationId: string,
   serviceId: string,
   config: ClickHouseConfig
-) {
-  const updateServiceScaling = async (scalingData: unknown) => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/services/${serviceId}/scaling`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(scalingData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    return response.json();
-  };
-  return { updateServiceScaling };
-}
+) => {
+  const { createPrivateEndpoint } = servicesHooks.useActions(
+    { organizationId, serviceId },
+    config
+  );
+  return { createPrivateEndpoint: (body: unknown) => createPrivateEndpoint(body) };
+};
+
+export const useServiceScaling = (
+  organizationId: string,
+  serviceId: string,
+  config: ClickHouseConfig
+) => {
+  const { updateScaling } = servicesHooks.useActions({ organizationId, serviceId }, config);
+  return { updateServiceScaling: (body: unknown) => updateScaling(body) };
+};
+

--- a/src/hooks/useUserManagement.ts
+++ b/src/hooks/useUserManagement.ts
@@ -1,230 +1,67 @@
-import { useSWRConfig } from "swr";
 import type { ClickHouseConfig } from "../api/fetcher";
-import { useClickHouseSWR } from "./useClickHouseSWR";
-import {
-  MembersResponseSchema,
-  MemberResponseSchema,
-  InvitationsResponseSchema,
-  InvitationResponseSchema,
-  ClickHouseBaseResponseSchema,
-} from "../schemas/schemas";
+import { membersHooks, orgInvitationsHooks } from "./resources/userManagement";
 import type {
   MemberPatchRequest,
   InvitationPostRequest,
-  Member,
-  Invitation,
-  ClickHouseBaseResponse,
 } from "../schemas/schemas";
 
-export function useOrganizationMembers(
+export const useOrganizationMembers = (
   organizationId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR(
-    `/v1/organizations/${organizationId}/members`,
-    config,
-    MembersResponseSchema
-  );
-}
+) => membersHooks.useList({ organizationId }, config);
 
-export function useOrganizationMember(
+export const useOrganizationMember = (
   organizationId: string,
   userId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR(
-    `/v1/organizations/${organizationId}/members/${userId}`,
-    config,
-    MemberResponseSchema
-  );
-}
+) => membersHooks.useOne({ organizationId, userId }, config);
 
-export function useUpdateOrganizationMember(
+export const useUpdateOrganizationMember = (
   organizationId: string,
   userId: string,
   config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
+) => {
+  const update = membersHooks.useUpdate({ organizationId, userId }, config);
+  return { updateMember: (body: MemberPatchRequest) => update(body) };
+};
 
-  const updateMember = async (
-    updateData: MemberPatchRequest
-  ): Promise<Member> => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/members/${userId}`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(updateData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-    const validated = MemberResponseSchema.parse(responseData);
-    await Promise.all([
-      globalMutate(
-        `/v1/organizations/${organizationId}/members:${config.baseUrl}:${config.keyId}`
-      ),
-      globalMutate(
-        `/v1/organizations/${organizationId}/members/${userId}:${config.baseUrl}:${config.keyId}`
-      ),
-    ]);
-    return validated.result;
-  };
-
-  return { updateMember };
-}
-
-export function useDeleteOrganizationMember(
+export const useDeleteOrganizationMember = (
   organizationId: string,
   userId: string,
   config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
+) => {
+  const del = membersHooks.useDelete({ organizationId, userId }, config);
+  return { deleteMember: () => del() };
+};
 
-  const deleteMember = async (): Promise<ClickHouseBaseResponse> => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/members/${userId}`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-    const validated = ClickHouseBaseResponseSchema.parse(responseData);
-    await Promise.all([
-      globalMutate(
-        `/v1/organizations/${organizationId}/members:${config.baseUrl}:${config.keyId}`
-      ),
-      globalMutate(
-        `/v1/organizations/${organizationId}/members/${userId}:${config.baseUrl}:${config.keyId}`
-      ),
-    ]);
-    return validated;
-  };
-
-  return { deleteMember };
-}
-
-export function useOrganizationInvitations(
+export const useOrganizationInvitations = (
   organizationId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR(
-    `/v1/organizations/${organizationId}/invitations`,
-    config,
-    InvitationsResponseSchema
-  );
-}
+) => orgInvitationsHooks.useList({ organizationId }, config);
 
-export function useCreateOrganizationInvitation(
-  organizationId: string,
-  config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
-
-  const createInvitation = async (
-    invitationData: InvitationPostRequest
-  ): Promise<Invitation> => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/invitations`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(invitationData),
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-    const validated = InvitationResponseSchema.parse(responseData);
-    await Promise.all([
-      globalMutate(
-        `/v1/organizations/${organizationId}/invitations:${config.baseUrl}:${config.keyId}`
-      ),
-    ]);
-    return validated.result;
-  };
-
-  return { createInvitation };
-}
-
-export function useOrganizationInvitation(
+export const useOrganizationInvitation = (
   organizationId: string,
   invitationId: string,
   config: ClickHouseConfig
-) {
-  return useClickHouseSWR(
-    `/v1/organizations/${organizationId}/invitations/${invitationId}`,
-    config,
-    InvitationResponseSchema
-  );
-}
+) => orgInvitationsHooks.useOne({ organizationId, invitationId }, config);
 
-export function useDeleteOrganizationInvitation(
+export const useCreateOrganizationInvitation = (
+  organizationId: string,
+  config: ClickHouseConfig
+) => {
+  const create = orgInvitationsHooks.useCreate({ organizationId }, config);
+  return { createInvitation: (body: InvitationPostRequest) => create(body) };
+};
+
+export const useDeleteOrganizationInvitation = (
   organizationId: string,
   invitationId: string,
   config: ClickHouseConfig
-) {
-  const { mutate: globalMutate } = useSWRConfig();
-
-  const deleteInvitation = async (): Promise<ClickHouseBaseResponse> => {
-    const {
-      keyId,
-      keySecret,
-      baseUrl = "https://api.clickhouse.cloud",
-    } = config;
-    const auth = btoa(`${keyId}:${keySecret}`);
-    const response = await fetch(
-      `${baseUrl}/v1/organizations/${organizationId}/invitations/${invitationId}`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Basic ${auth}`,
-          "Content-Type": "application/json",
-        },
-      }
-    );
-    if (!response.ok) throw new Error(await response.text());
-    const responseData = await response.json();
-    const validated = ClickHouseBaseResponseSchema.parse(responseData);
-    await Promise.all([
-      globalMutate(
-        `/v1/organizations/${organizationId}/invitations:${config.baseUrl}:${config.keyId}`
-      ),
-      globalMutate(
-        `/v1/organizations/${organizationId}/invitations/${invitationId}:${config.baseUrl}:${config.keyId}`
-      ),
-    ]);
-    return validated;
-  };
-
-  return { deleteInvitation };
-}
+) => {
+  const del = orgInvitationsHooks.useDelete(
+    { organizationId, invitationId },
+    config
+  );
+  return { deleteInvitation: () => del() };
+};
 


### PR DESCRIPTION
## Summary
- centralize auth + SWR helpers in `_core` and generic `createResourceHooks`
- rebuild API-specific hooks using the shared factory
- update backup page example and tests for new hooks

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6898de92ea388324ab35e21e104734d4